### PR TITLE
Ability to override config on per-instance basis

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ val scalaV = "2.11.7"
 
 scalaVersion := scalaV
 
-val AkkaV = "2.4.0-RC3"
+val AkkaV = "2.4.0"
 
 val pomXtra = {
   <url>https://github.com/scullxbones/akka-persistence-mongo</url>

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val releaseV = "1.0.5"
+val releaseV = "1.0.6"
 
 val scalaV = "2.11.7"
 

--- a/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahJournalUpgradeSpec.scala
+++ b/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahJournalUpgradeSpec.scala
@@ -1,3 +1,3 @@
 package akka.contrib.persistence.mongodb
 
-class CasbahJournalUpgradeSpec extends JournalUpgradeSpec(classOf[CasbahPersistenceExtension], as => new CasbahMongoDriver(as))
+class CasbahJournalUpgradeSpec extends JournalUpgradeSpec(classOf[CasbahPersistenceExtension], new CasbahMongoDriver(_,_))

--- a/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahPersistenceDriverSpec.scala
+++ b/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahPersistenceDriverSpec.scala
@@ -28,8 +28,8 @@ class CasbahPersistenceDriverShutdownSpec extends BaseUnitTest with EmbeddedMong
         |}
       """.stripMargin)
 
-  "A casbah driver" should "close the mongodb connection pool on actor system shutdown" in withConfig(shutdownConfig) { actorSystem =>
-    val underTest = new CasbahMongoDriver(actorSystem)
+  "A casbah driver" should "close the mongodb connection pool on actor system shutdown" in withConfig(shutdownConfig, "akka-contrib-mongodb-persistence-journal") { case (actorSystem,config) =>
+    val underTest = new CasbahMongoDriver(actorSystem, config)
     underTest.actorSystem.terminate()
     Await.result(underTest.actorSystem.whenTerminated,10.seconds)
     intercept[IllegalStateException] {
@@ -39,14 +39,14 @@ class CasbahPersistenceDriverShutdownSpec extends BaseUnitTest with EmbeddedMong
   }
 
 
-  it should "reconnect if a new driver is created" in withConfig(shutdownConfig)  { actorSystem =>
-    val underTest = new CasbahMongoDriver(actorSystem)
+  it should "reconnect if a new driver is created" in withConfig(shutdownConfig, "akka-contrib-mongodb-persistence-journal")  { case (actorSystem,config) =>
+    val underTest = new CasbahMongoDriver(actorSystem, config)
     underTest.db.collectionNames()
     underTest.actorSystem.terminate()
     Await.result(underTest.actorSystem.whenTerminated,10.seconds)
 
     val newAs:ActorSystem = ActorSystem("test2",shutdownConfig)
-    val underTest2 = new CasbahMongoDriver(newAs)
+    val underTest2 = new CasbahMongoDriver(newAs, config)
     underTest2.db.collectionNames()
     newAs.terminate()
     ()
@@ -74,8 +74,8 @@ class CasbahPersistenceDriverAuthSpec extends BaseUnitTest with EmbeddedMongo wi
         |}
       """.stripMargin)
 
-  "A secured mongodb instance" should "be connectable via user and pass" in withConfig(authConfig) { actorSystem =>
-    val underTest = new CasbahMongoDriver(actorSystem)
+  "A secured mongodb instance" should "be connectable via user and pass" in withConfig(authConfig, "akka-contrib-mongodb-persistence-journal") { case (actorSystem,config) =>
+    val underTest = new CasbahMongoDriver(actorSystem, config)
     val collections = underTest.db.collectionNames()
     collections should contain ("system.users")
     ()

--- a/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahPersistenceSpec.scala
+++ b/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahPersistenceSpec.scala
@@ -2,6 +2,7 @@ package akka.contrib.persistence.mongodb
 
 import akka.pattern.CircuitBreaker
 import akka.testkit.TestKit
+import com.typesafe.config.ConfigFactory
 import scala.concurrent.duration._
 import scala.language.postfixOps
 import com.mongodb.casbah.{MongoClient, MongoCollection}
@@ -10,7 +11,7 @@ trait CasbahPersistenceSpec extends MongoPersistenceSpec[CasbahMongoDriver,Mongo
 
     lazy val mongoDB = MongoClient(embedConnectionURL,embedConnectionPort)(embedDB)
 
-    override val driver = new CasbahMongoDriver(system) {
+    override val driver = new CasbahMongoDriver(system, ConfigFactory.empty()) {
       override lazy val breaker = CircuitBreaker(system.scheduler, 0, 10 seconds, 10 seconds)
       override def collection(name: String) = mongoDB(name)
     }

--- a/common/src/main/scala/akka/contrib/persistence/mongodb/MongoJournal.scala
+++ b/common/src/main/scala/akka/contrib/persistence/mongodb/MongoJournal.scala
@@ -4,6 +4,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import akka.actor.Actor
 import akka.pattern.{CircuitBreakerOpenException, CircuitBreaker}
+import com.typesafe.config.Config
 
 import scala.collection.immutable
 import akka.persistence.journal.AsyncWriteJournal
@@ -16,9 +17,9 @@ import nl.grons.metrics.scala.Timer
 import scala.util.Try
 import scala.concurrent.duration._
 
-class MongoJournal extends AsyncWriteJournal {
+class MongoJournal(config: Config) extends AsyncWriteJournal {
   
-  private[this] val impl = MongoPersistenceExtension(context.system).journaler
+  private[this] val impl = MongoPersistenceExtension(context.system)(config).journaler
   private[this] implicit val ec = context.dispatcher
 
   /**

--- a/common/src/main/scala/akka/contrib/persistence/mongodb/MongoReadJournal.scala
+++ b/common/src/main/scala/akka/contrib/persistence/mongodb/MongoReadJournal.scala
@@ -7,14 +7,15 @@ import akka.persistence.query.javadsl.{CurrentEventsByPersistenceIdQuery => JCEB
 import akka.stream.actor.{ActorPublisher, ActorPublisherMessage}
 import akka.stream.scaladsl.Source
 import akka.stream.javadsl.{Source => JSource}
+import com.typesafe.config.Config
 
 object MongoReadJournal {
   val Identifier = "akka-contrib-mongodb-persistence-readjournal"
 }
 
-class MongoReadJournal(system: ExtendedActorSystem) extends ReadJournalProvider {
+class MongoReadJournal(system: ExtendedActorSystem, config: Config) extends ReadJournalProvider {
 
-  private[this] val impl = MongoPersistenceExtension(system).readJournal
+  private[this] val impl = MongoPersistenceExtension(system)(config).readJournal
 
   override def scaladslReadJournal(): scaladsl.ReadJournal = new ScalaDslMongoReadJournal(impl)
 

--- a/common/src/main/scala/akka/contrib/persistence/mongodb/MongoSnapshots.scala
+++ b/common/src/main/scala/akka/contrib/persistence/mongodb/MongoSnapshots.scala
@@ -4,14 +4,15 @@ import akka.actor.Actor
 import akka.pattern.CircuitBreaker
 import akka.persistence.snapshot.SnapshotStore
 import akka.persistence.SnapshotSelectionCriteria
+import com.typesafe.config.Config
 import scala.concurrent.Future
 import akka.persistence.SnapshotMetadata
 import akka.persistence.SelectedSnapshot
 import scala.concurrent.ExecutionContext
 
-class MongoSnapshots extends SnapshotStore {
+class MongoSnapshots(config: Config) extends SnapshotStore {
 
-  private[this] val impl = MongoPersistenceExtension(context.system).snapshotter
+  private[this] val impl = MongoPersistenceExtension(context.system)(config).snapshotter
   private[this] implicit val ec = context.dispatcher
   
   /**

--- a/common/src/test/scala/akka/contrib/persistence/mongodb/BaseUnitTest.scala
+++ b/common/src/test/scala/akka/contrib/persistence/mongodb/BaseUnitTest.scala
@@ -1,23 +1,24 @@
 package akka.contrib.persistence.mongodb
 
 import akka.actor.ActorSystem
-import com.typesafe.config.Config
+import com.typesafe.config.{ConfigFactory, Config}
 import org.scalatest.Matchers
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.FlatSpecLike
 
 import scala.concurrent.Await
-import scala.concurrent.duration.Duration
+import scala.util.Try
 
 trait BaseUnitTest extends FlatSpecLike with MockitoSugar with Matchers
 
 object ConfigLoanFixture {
   import concurrent.duration._
 
-  def withConfig[T](config: Config, name: String = "unit-test")(testCode: ActorSystem => T):T = {
+  def withConfig[T](config: Config, configurationRoot: String, name: String = "unit-test")(testCode: ((ActorSystem,Config)) => T):T = {
     val actorSystem: ActorSystem = ActorSystem(name,config)
+    val overrides = Try(config.getConfig(configurationRoot)).toOption.getOrElse(ConfigFactory.empty())
     try {
-      testCode(actorSystem)
+      testCode( (actorSystem, overrides) )
     } finally {
       actorSystem.terminate()
       Await.result(actorSystem.whenTerminated, 3.seconds)

--- a/common/src/test/scala/akka/contrib/persistence/mongodb/JournalLoadSpec.scala
+++ b/common/src/test/scala/akka/contrib/persistence/mongodb/JournalLoadSpec.scala
@@ -128,7 +128,7 @@ abstract class JournalLoadSpec(extensionClass: Class[_]) extends BaseUnitTest wi
   def startPersistentActors(as: ActorSystem, eventsPer: Int, maxDuration: FiniteDuration) =
     persistenceIds.map(nm => as.actorOf(actorProps(nm, eventsPer, maxDuration),s"counter-$nm")).toSet
 
-  "A mongo persistence driver" should "insert journal records at a rate faster than 10000/s" in withConfig(config(extensionClass), "load-test") { as =>
+  "A mongo persistence driver" should "insert journal records at a rate faster than 10000/s" in withConfig(config(extensionClass), "akka-contrib-mongodb-persistence-journal", "load-test") { case (as,config) =>
     val thousand = 1 to commandsPerBatch
     val actors = startPersistentActors(as, commandsPerBatch * batches, 60.seconds)
     val result = Promise[Long]()
@@ -145,7 +145,7 @@ abstract class JournalLoadSpec(extensionClass: Class[_]) extends BaseUnitTest wi
     println(s"$total events: $time ms ... ${total.map(_/(time / 1000.0)).map(_.toString).getOrElse("N/A")}")
   }
 
-  it should "recover in less than 20 seconds" in withConfig(config(extensionClass), "load-test") { as =>
+  it should "recover in less than 20 seconds" in withConfig(config(extensionClass), "akka-contrib-mongodb-persistence-journal", "load-test") { case (as,config) =>
     val start = System.currentTimeMillis
     val actors = startPersistentActors(as, 0, 100.milliseconds)
     val result = Promise[Long]()

--- a/common/src/test/scala/akka/contrib/persistence/mongodb/JournalSerializableSpec.scala
+++ b/common/src/test/scala/akka/contrib/persistence/mongodb/JournalSerializableSpec.scala
@@ -79,7 +79,7 @@ abstract class JournalSerializableSpec(extensionClass: Class[_]) extends BaseUni
   implicit val defaultPatience =
     PatienceConfig(timeout = Span(5, Seconds), interval = Span(500, Millis))
 
-  "A journal" should "support writing serializable events" in withConfig(config(extensionClass)) { as =>
+  "A journal" should "support writing serializable events" in withConfig(config(extensionClass), "akka-contrib-mongodb-persistence-journal") { case (as,_) =>
     implicit val system = as
     val pa = as.actorOf(OrderIdActor.props)
     pa ! Increment
@@ -91,7 +91,7 @@ abstract class JournalSerializableSpec(extensionClass: Class[_]) extends BaseUni
     }
   }
 
-  it should "support restoring serializable events" in withConfig(config(extensionClass)) { as =>
+  it should "support restoring serializable events" in withConfig(config(extensionClass), "akka-contrib-mongodb-persistence-journal") { case (as,_) =>
     implicit val system = as
     val pa = as.actorOf(OrderIdActor.props)
     whenReady((pa ? Get)(5.second.dilated)) {

--- a/common/src/test/scala/akka/contrib/persistence/mongodb/MongoExtensionSpec.scala
+++ b/common/src/test/scala/akka/contrib/persistence/mongodb/MongoExtensionSpec.scala
@@ -1,7 +1,7 @@
 package akka.contrib.persistence.mongodb
 
 import akka.actor.ActorSystem
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{Config, ConfigFactory}
 
 class MongoExtensionSpec extends BaseUnitTest {
 
@@ -25,10 +25,15 @@ class MongoExtensionSpec extends BaseUnitTest {
 }
 
 class StubbyMongoPersistenceExtension(actorSystem: ActorSystem) extends MongoPersistenceExtension {
-  override def journaler: MongoPersistenceJournallingApi = null
 
-  override def snapshotter: MongoPersistenceSnapshottingApi = null
+  case class StubbyConfiguredExtension(config: Config) extends ConfiguredExtension {
+    override def journaler: MongoPersistenceJournallingApi = null
 
-  override def readJournal: MongoPersistenceReadJournallingApi = null
+    override def snapshotter: MongoPersistenceSnapshottingApi = null
+
+    override def readJournal: MongoPersistenceReadJournallingApi = null
+  }
+
+  override def configured(config: Config): ConfiguredExtension = StubbyConfiguredExtension(config)
 }
 

--- a/common/src/test/scala/akka/contrib/persistence/mongodb/MongoSettingsSpec.scala
+++ b/common/src/test/scala/akka/contrib/persistence/mongodb/MongoSettingsSpec.scala
@@ -40,7 +40,7 @@ class MongoSettingsSpec extends BaseUnitTest {
       """.stripMargin)
 
   def fixture[A](config: Config)(testCode: MongoSettings => A): A = {
-    testCode(new MongoSettings(new ActorSystem.Settings(getClass.getClassLoader,config,"settings name")))
+    testCode(MongoSettings(new ActorSystem.Settings(getClass.getClassLoader,config,"settings name")))
   }
 
   "A settings object" should "correctly load the defaults" in fixture(reference) { s =>
@@ -61,5 +61,14 @@ class MongoSettingsSpec extends BaseUnitTest {
 
   it should "correctly load legacy credentials" in fixture(withCredentialsLegacy) { s =>
     s.MongoUri shouldBe "mongodb://user:pass@mongo1.example.com:27017/spec_db"
+  }
+
+  it should "allow for override" in fixture(withUri) { s =>
+    val overridden = ConfigFactory.parseString("""
+        |mongouri = "mongodb://localhost:27017/override"
+      """.stripMargin)
+    s.withOverride(overridden).MongoUri shouldBe "mongodb://localhost:27017/override"
+    s.withOverride(overridden).Implementation shouldBe "foo"
+    s.withOverride(overridden).JournalAutomaticUpgrade shouldBe false
   }
 }

--- a/common/src/test/scala/akka/contrib/persistence/mongodb/ReadJournalSpec.scala
+++ b/common/src/test/scala/akka/contrib/persistence/mongodb/ReadJournalSpec.scala
@@ -38,6 +38,10 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
     |    # Class name of the plugin.
     |  class = "akka.contrib.persistence.mongodb.MongoSnapshots"
     |}
+    |akka-contrib-mongodb-persistence-readjournal {
+    |  # Class name of the plugin.
+    |  class = "akka.contrib.persistence.mongodb.MongoReadJournal"
+    |}
     |""".stripMargin).withFallback(ConfigFactory.defaultReference())
 
   def props(id: String, promise: Promise[Unit]) = Props(new Persistent(id, promise))
@@ -63,7 +67,7 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
   }
 
 
-  "A read journal" should "support the journal dump query" in withConfig(config(extensionClass)) { as =>
+  "A read journal" should "support the journal dump query" in withConfig(config(extensionClass), "akka-contrib-mongodb-persistence-readjournal") { case (as,_) =>
     import concurrent.duration._
     implicit val system = as
     implicit val mat = ActorMaterializer()
@@ -90,7 +94,7 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
     Await.result(fut,10.seconds) shouldBe empty
   }
 
-  it should "support the all persistence ids query" in withConfig(config(extensionClass)) { as =>
+  it should "support the all persistence ids query" in withConfig(config(extensionClass), "akka-contrib-mongodb-persistence-readjournal") { case (as,_)  =>
     import concurrent.duration._
     implicit val system = as
     implicit val mat = ActorMaterializer()
@@ -113,7 +117,7 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
     Await.result(fut,10.seconds) should contain allOf("1","2","3","4","5")
   }
 
-  it should "support the events by id query" in withConfig(config(extensionClass)) { as =>
+  it should "support the events by id query" in withConfig(config(extensionClass), "akka-contrib-mongodb-persistence-readjournal") { case (as,_) =>
     import concurrent.duration._
     implicit val system = as
     implicit val mat = ActorMaterializer()

--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoReadJournaller.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoReadJournaller.scala
@@ -67,7 +67,7 @@ class AllEvents(val driver: RxMongoDriver) extends IterateeActorPublisher[EventE
     Enumerator(
       doc.as[BSONArray](EVENTS).values.collect {
         case d:BSONDocument => driver.deserializeJournal(d)
-      }.zipWithIndex.map{case (ev,idx) => ev.toEnvelope(idx)} : _*
+      }.zipWithIndex.map{case (ev,idx) => ev.toEnvelope(idx.toLong)} : _*
     )
   }
 
@@ -119,7 +119,7 @@ class EventsByPersistenceId(val driver:RxMongoDriver,persistenceId:String,fromSe
     Enumerator(
       doc.as[BSONArray](EVENTS).values.collect {
         case d:BSONDocument => driver.deserializeJournal(d)
-      }.zipWithIndex.map{case (ev,idx) => ev.toEnvelope(idx)} : _*
+      }.zipWithIndex.map{case (ev,idx) => ev.toEnvelope(idx.toLong)} : _*
     )
   }
 

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoJournalUpgradeSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoJournalUpgradeSpec.scala
@@ -1,3 +1,3 @@
 package akka.contrib.persistence.mongodb
 
-class RxMongoJournalUpgradeSpec extends JournalUpgradeSpec(classOf[RxMongoPersistenceExtension], as => new RxMongoDriver(as))
+class RxMongoJournalUpgradeSpec extends JournalUpgradeSpec(classOf[RxMongoPersistenceExtension], new RxMongoDriver(_,_))

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceDriverSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceDriverSpec.scala
@@ -25,12 +25,12 @@ class RxMongoPersistenceDriverShutdownSpec extends BaseUnitTest with EmbeddedMon
         |}
       """.stripMargin)
 
-  class MockRxMongoPersistenceDriver(actorSystem:ActorSystem) extends RxMongoDriver(actorSystem) {
+  class MockRxMongoPersistenceDriver(actorSystem:ActorSystem) extends RxMongoDriver(actorSystem, ConfigFactory.empty()) {
     def showCollections = db.collectionNames
   }
 
 
-  "An rxmongo driver" should "close the mongodb connection pool on actor system shutdown" in withConfig(shutdownConfig,"shutdown-config") { actorSystem =>
+  "An rxmongo driver" should "close the mongodb connection pool on actor system shutdown" in withConfig(shutdownConfig,"akka-contrib-mongodb-persistence-journal","shutdown-config") { case (actorSystem,_) =>
     val underTest = new MockRxMongoPersistenceDriver(actorSystem)
     underTest.actorSystem.terminate()
     Await.result(underTest.actorSystem.whenTerminated, 10.seconds)
@@ -41,7 +41,7 @@ class RxMongoPersistenceDriverShutdownSpec extends BaseUnitTest with EmbeddedMon
   }
 
 
-  it should "reconnect if a new driver is created" in withConfig(shutdownConfig,"shutdown-config") { actorSystem =>
+  it should "reconnect if a new driver is created" in withConfig(shutdownConfig,"akka-contrib-mongodb-persistence-journal","shutdown-config") { case (actorSystem,_) =>
     val underTest = new MockRxMongoPersistenceDriver(actorSystem)
     underTest.actorSystem.terminate()
     Await.result(underTest.actorSystem.whenTerminated, 10.seconds)
@@ -76,8 +76,8 @@ class RxMongoPersistenceDriverAuthSpec extends BaseUnitTest with EmbeddedMongo w
         |}
       """.stripMargin)
 
-  "A secured mongodb instance" should "be connectable via user and pass" in withConfig(authConfig,"authentication-config") { actorSystem =>
-    val underTest = new RxMongoDriver(actorSystem)
+  "A secured mongodb instance" should "be connectable via user and pass" in withConfig(authConfig,"akka-contrib-mongodb-persistence-journal","authentication-config") { case (actorSystem, config) =>
+    val underTest = new RxMongoDriver(actorSystem, config)
     val collections = Await.result(underTest.db.collectionNames,3.seconds)
     collections should contain ("system.users")
     ()

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceSpec.scala
@@ -2,6 +2,7 @@ package akka.contrib.persistence.mongodb
 
 import akka.pattern.CircuitBreaker
 import akka.testkit.TestKit
+import com.typesafe.config.ConfigFactory
 import reactivemongo.api.MongoDriver
 import reactivemongo.api.collections.bson.BSONCollection
 import reactivemongo.bson.BSONDocument
@@ -18,7 +19,7 @@ trait RxMongoPersistenceSpec extends MongoPersistenceSpec[RxMongoDriver, BSONCol
   }
   lazy val specDb = connection(embedDB)
 
-  class SpecDriver extends RxMongoDriver(system) {
+  class SpecDriver extends RxMongoDriver(system, ConfigFactory.empty()) {
     override def db = specDb
     override lazy val breaker = CircuitBreaker(system.scheduler, 0, 10.seconds, 10.seconds)
     override def collection(name: String) = specDb(name)


### PR DESCRIPTION
* Looks for a `overrides` config object to supply
* Fixes issue #43
* keys at the level `akka.contrib.persistence.mongodb.mongo` are assumed