### PR TITLE
Add support for legacy (0.x) serialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ env:
    - MONGODB_VERSION=2.6
    - MONGODB_VERSION=3.0
   global:
-    _JAVA_OPTIONS="-Xmx2G -Dakka.test.timefactor=4"
+    _JAVA_OPTIONS="-Xmx2G -Dakka.test.timefactor=5"
 jdk:
   - oraclejdk8

--- a/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceExtension.scala
+++ b/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceExtension.scala
@@ -58,7 +58,7 @@ class CasbahMongoDriver(system: ActorSystem, config: Config) extends MongoPersis
     logger.info(s"Journal automatic upgrade found $cnt records needing upgrade")
     if(cnt > 0) {
       val results = j.find[DBObject](q)
-       .map(d => d.as[ObjectId]("_id") -> deserializeJournal(d))
+       .map(d => d.as[ObjectId]("_id") -> Event[DBObject](useLegacySerialization)(deserializeJournal(d).toRepr))
        .map{case (id,ev) => j.update("_id" $eq id, serializeJournal(Atom(ev.pid, ev.sn, ev.sn, ISeq(ev))))}
       results.foldLeft((0, 0)) { case ((successes, failures), result) =>
         val n = result.getN

--- a/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournaller.scala
+++ b/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournaller.scala
@@ -31,7 +31,7 @@ class CasbahPersistenceJournaller(driver: CasbahMongoDriver) extends MongoPersis
 
   import collection.immutable.{Seq => ISeq}
   private[mongodb] override def batchAppend(writes: ISeq[AtomicWrite])(implicit ec: ExecutionContext):Future[ISeq[Try[Unit]]] = Future {
-    val batch = writes.map(write => Try(driver.serializeJournal(Atom[DBObject](write))))
+    val batch = writes.map(write => Try(driver.serializeJournal(Atom[DBObject](write, driver.useLegacySerialization))))
     if (batch.forall(_.isSuccess)) {
       val bulk = journal.initializeOrderedBulkOperation
       batch.collect { case scala.util.Success(ser) => ser } foreach bulk.insert

--- a/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceReadJournaller.scala
+++ b/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceReadJournaller.scala
@@ -46,7 +46,7 @@ class AllEvents(val driver: CasbahMongoDriver) extends SyncActorPublisher[EventE
           .flatMap(lst => lst.collect {case x:DBObject => x} )
           .map(driver.deserializeJournal)
           .zipWithIndex
-          .map { case(e,i) => e.toEnvelope(i) }
+          .map { case(e,i) => e.toEnvelope(i.toLong) }
 
   override protected def next(c: Stream[EventEnvelope], atMost: Long): (Vector[EventEnvelope], Stream[EventEnvelope]) = {
     val (buf,remainder) = c.splitAt(atMost.toIntWithoutWrapping)
@@ -76,7 +76,7 @@ class EventsByPersistenceId(val driver: CasbahMongoDriver, persistenceId: String
       .filter(dbo => dbo.getAs[Long](SEQUENCE_NUMBER).exists(sn => sn >= fromSeq && sn <= toSeq))
       .map(driver.deserializeJournal)
       .zipWithIndex
-      .map { case(e,i) => e.toEnvelope(i) }
+      .map { case(e,i) => e.toEnvelope(i.toLong) }
 
   override protected def next(c: Stream[EventEnvelope], atMost: Long): (Vector[EventEnvelope], Stream[EventEnvelope]) = {
     val (buf,remainder) = c.splitAt(atMost.toIntWithoutWrapping)

--- a/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahSerializers.scala
+++ b/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahSerializers.scala
@@ -49,7 +49,7 @@ object CasbahSerializers extends JournallingFieldNames {
         case _ =>
           val content = d.as[Array[Byte]](SERIALIZED)
           val repr = Serialized(content, classOf[PersistentRepr], None)
-          Event[DBObject](repr.content).copy(pid = persistenceId, sn = sequenceNr)
+          Event[DBObject](useLegacySerialization = false)(repr.content).copy(pid = persistenceId, sn = sequenceNr)
       }
 
     }
@@ -90,6 +90,7 @@ object CasbahSerializers extends JournallingFieldNames {
       payload match {
         case Bson(doc: DBObject) => builder += PayloadKey -> doc
         case Bin(bytes) => builder += PayloadKey -> bytes
+        case Legacy(bytes) => builder += PayloadKey -> bytes
         case s: Serialized[_] => builder ++= (PayloadKey -> s.bytes :: HINT -> s.clazz.getName :: SER_MANIFEST -> s.serializedManifest :: Nil)
         case StringPayload(str) => builder += PayloadKey -> str
         case FloatingPointPayload(d) => builder += PayloadKey -> d

--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -31,6 +31,8 @@ akka {
               reset = 5s
             }
           }
+
+          use-legacy-serialization = false
         }
       }
     }

--- a/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistence.scala
+++ b/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistence.scala
@@ -115,6 +115,7 @@ abstract class MongoPersistenceDriver(as: ActorSystem, config: Config) {
   def journalWTimeout = settings.JournalWTimeout
   def journalFsync = settings.JournalFSync
   def mongoUri = settings.MongoUri
+  def useLegacySerialization = settings.UseLegacyJournalSerialization
 
   def deserializeJournal(dbo: D)(implicit ev: CanDeserializeJournal[D]) = ev.deserializeDocument(dbo)
   def serializeJournal(aw: Atom)(implicit ev: CanSerializeJournal[D]) = ev.serializeAtom(aw)

--- a/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistenceExtension.scala
+++ b/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistenceExtension.scala
@@ -101,4 +101,6 @@ class MongoSettings(val config: Config) {
   val ResetTimeout = config.getDuration("breaker.timeout.reset", MILLISECONDS).millis
 
   val ReadJournalPerFillLimit = config.getInt("journal-read-fill-limit")
+
+  val UseLegacyJournalSerialization = config.getBoolean("use-legacy-serialization")
 }

--- a/common/src/test/scala/akka/contrib/persistence/mongodb/Journal1kSpec.scala
+++ b/common/src/test/scala/akka/contrib/persistence/mongodb/Journal1kSpec.scala
@@ -1,8 +1,7 @@
 package akka.contrib.persistence.mongodb
 
-import akka.actor.{ExtendedActorSystem, Props}
+import akka.actor.Props
 import akka.persistence.PersistentActor
-import akka.serialization.{SerializerWithStringManifest, Serializer}
 import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfterAll
@@ -23,6 +22,7 @@ abstract class Journal1kSpec(extensionClass: Class[_]) extends BaseUnitTest with
   }
 
   def config(extensionClass: Class[_]) = ConfigFactory.parseString(s"""
+    |akka.contrib.persistence.mongodb.mongo.use-legacy-serialization = true
     |akka.contrib.persistence.mongodb.mongo.driver = "${extensionClass.getName}"
     |akka.contrib.persistence.mongodb.mongo.mongouri = "mongodb://localhost:$embedConnectionPort/$embedDB"
     |akka.contrib.persistence.mongodb.mongo.breaker.timeout.call = 0s

--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoJournaller.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoJournaller.scala
@@ -45,7 +45,7 @@ class RxMongoJournaller(driver: RxMongoDriver) extends MongoPersistenceJournalli
   }
 
   private[mongodb] override def batchAppend(writes: ISeq[AtomicWrite])(implicit ec: ExecutionContext):Future[ISeq[Try[Unit]]] = {
-    val batch = writes.toStream.map(aw => Try(driver.serializeJournal(Atom[BSONDocument](aw))))
+    val batch = writes.toStream.map(aw => Try(driver.serializeJournal(Atom[BSONDocument](aw, driver.useLegacySerialization))))
     Future.sequence(batch.map {
       case Success(document:BSONDocument) => journal.insert(document, writeConcern).map(writeResultToUnit)
       case f:Failure[_] => Future.successful(Failure[Unit](f.exception))


### PR DESCRIPTION
* If config "use-legacy-serialization" set:
  * Store `PersistentRepr` whole in payload as bin
  * Fully delegate serialization to akka-ser
  * Use type = 'repr'

Also
* Fix numeric widening warning
* Remove old .gitkeep file
* Go to 5x in akka dilation for travis

Fixes #60