### PR TITLE
Use explicit database config instead of url specified auth db

### DIFF
--- a/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceExtension.scala
+++ b/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceExtension.scala
@@ -80,7 +80,7 @@ class CasbahMongoDriver(system: ActorSystem, config: Config) extends MongoPersis
 
   private[mongodb] lazy val client = MongoClient(url)
 
-  private[mongodb] lazy val db = client(url.database.getOrElse(DEFAULT_DB_NAME))
+  private[mongodb] lazy val db = client(databaseName.getOrElse(DEFAULT_DB_NAME))
 
   private[mongodb] def collection(name: String) = db(name)
   private[mongodb] def journalWriteConcern: WriteConcern = toWriteConcern(journalWriteSafety,journalWTimeout,journalFsync)

--- a/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceExtension.scala
+++ b/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceExtension.scala
@@ -80,7 +80,7 @@ class CasbahMongoDriver(system: ActorSystem, config: Config) extends MongoPersis
 
   private[mongodb] lazy val client = MongoClient(url)
 
-  private[mongodb] lazy val db = client(databaseName.getOrElse(DEFAULT_DB_NAME))
+  private[mongodb] lazy val db = client(databaseName.getOrElse(url.database.getOrElse(DEFAULT_DB_NAME)))
 
   private[mongodb] def collection(name: String) = db(name)
   private[mongodb] def journalWriteConcern: WriteConcern = toWriteConcern(journalWriteSafety,journalWTimeout,journalFsync)

--- a/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahPersistenceDriverSpec.scala
+++ b/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahPersistenceDriverSpec.scala
@@ -71,6 +71,7 @@ class CasbahPersistenceDriverAuthSpec extends BaseUnitTest with EmbeddedMongo wi
     s"""
         |akka.contrib.persistence.mongodb.mongo {
         | mongouri = "mongodb://admin:password@localhost:$embedConnectionPort/admin"
+        | database = "admin"
         |}
       """.stripMargin)
 

--- a/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistence.scala
+++ b/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistence.scala
@@ -104,6 +104,7 @@ abstract class MongoPersistenceDriver(as: ActorSystem, config: Config) {
                       TIMESTAMP -> -1)(concurrent.ExecutionContext.Implicits.global)
   }
 
+  def databaseName = settings.Database
   def snapsCollectionName = settings.SnapsCollection
   def snapsIndexName = settings.SnapsIndex
   def snapsWriteSafety: WriteSafety = settings.SnapsWriteConcern

--- a/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistenceExtension.scala
+++ b/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistenceExtension.scala
@@ -82,6 +82,8 @@ class MongoSettings(val config: Config) {
       }) getOrElse s"mongodb://$Urls/$DbName"
   }
 
+  val Database = Try(config.getString("database")).toOption
+
   val JournalCollection = config.getString("journal-collection")
   val JournalIndex = config.getString("journal-index")
   val JournalWriteConcern = config.getString("journal-write-concern")

--- a/common/src/test/scala/akka/contrib/persistence/mongodb/JournalUpgradeSpec.scala
+++ b/common/src/test/scala/akka/contrib/persistence/mongodb/JournalUpgradeSpec.scala
@@ -33,6 +33,7 @@ abstract class JournalUpgradeSpec[D <: MongoPersistenceDriver, X <: MongoPersist
     |  class = "akka.contrib.persistence.mongodb.MongoJournal"
     |  overrides {
     |     mongouri = "mongodb://localhost:$embedConnectionPort/$embedDB"
+    |     database = $embedDB
     |  }
     |}
     |akka.persistence.snapshot-store.plugin = "akka-contrib-mongodb-persistence-snapshot"

--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceExtension.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceExtension.scala
@@ -147,7 +147,7 @@ class RxMongoDriver(system: ActorSystem, config: Config) extends MongoPersistenc
 
   private[mongodb] def closeConnections(): Unit = driver.close()
 
-  private[mongodb] def dbName: String = parsedMongoUri.db.getOrElse(DEFAULT_DB_NAME)
+  private[mongodb] def dbName: String = databaseName.getOrElse(DEFAULT_DB_NAME)
   private[mongodb] def db = connection(dbName)(system.dispatcher)
 
   private[mongodb] override def collection(name: String) = db[BSONCollection](name)

--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceExtension.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceExtension.scala
@@ -147,7 +147,7 @@ class RxMongoDriver(system: ActorSystem, config: Config) extends MongoPersistenc
 
   private[mongodb] def closeConnections(): Unit = driver.close()
 
-  private[mongodb] def dbName: String = databaseName.getOrElse(DEFAULT_DB_NAME)
+  private[mongodb] def dbName: String = databaseName.getOrElse(parsedMongoUri.db.getOrElse(DEFAULT_DB_NAME))
   private[mongodb] def db = connection(dbName)(system.dispatcher)
 
   private[mongodb] override def collection(name: String) = db[BSONCollection](name)

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceDriverSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceDriverSpec.scala
@@ -73,6 +73,7 @@ class RxMongoPersistenceDriverAuthSpec extends BaseUnitTest with EmbeddedMongo w
     s"""
         |akka.contrib.persistence.mongodb.mongo {
         | mongouri = "mongodb://admin:password@localhost:$embedConnectionPort/admin$authMode"
+        | database = "admin"
         |}
       """.stripMargin)
 


### PR DESCRIPTION
First thanks to your work , we are using akka-persistence-mongo in our production environment, but there is a small question described as below.
In [Mongodb connection string URI](https://docs.mongodb.org/manual/reference/connection-string/) format, the /database is used as authentication database, default is "admin", not for save our production data
```
/database
Optional. The name of the database to authenticate if the connection string includes authentication credentials in the form of username:password@. 
If /database is not specified and the connection string includes credentials, the driver will authenticate to the admin database.
```
If we want to save akka journal or snapshot to some database other than the authentication database "admin" , we have to create a new user which can authenticate to the database we created without authenticate to "admin" first, it is a little hard and wired. So I suggest add a explicit "database" config used as akka journal/snapshot database, example as below:
```
mongouri = "mongodb://xxx:xxx@host:port/authenticateDatabase"
database = "xxxx"
journal-collection = "persistent_journal"
journal-index = "journal_index"
snaps-collection = "persistent_snapshots"
snaps-index = "snaps_index"
journal-write-concern = "Acknowledged"
```