### PR TITLE
Add explicit database config instead of default authenticationDB

### DIFF
--- a/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceExtension.scala
+++ b/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceExtension.scala
@@ -80,7 +80,7 @@ class CasbahMongoDriver(system: ActorSystem, config: Config) extends MongoPersis
 
   private[mongodb] lazy val client = MongoClient(url)
 
-  private[mongodb] lazy val db = client(url.database.getOrElse(DEFAULT_DB_NAME))
+  private[mongodb] lazy val db = client(databaseName.getOrElse(url.database.getOrElse(DEFAULT_DB_NAME)))
 
   private[mongodb] def collection(name: String) = db(name)
   private[mongodb] def journalWriteConcern: WriteConcern = toWriteConcern(journalWriteSafety,journalWTimeout,journalFsync)

--- a/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahDatabaseConfigSpec.scala
+++ b/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahDatabaseConfigSpec.scala
@@ -1,0 +1,36 @@
+package akka.contrib.persistence.mongodb
+
+import akka.contrib.persistence.mongodb.ConfigLoanFixture._
+import com.typesafe.config.ConfigFactory
+import org.scalatest.BeforeAndAfterAll
+
+/**
+  * Short description
+  * @author  wanglei
+  * @since   15-11-28
+  * @version 1.0
+  */
+class CasbahDatabaseConfigSpec extends BaseUnitTest with EmbeddedMongo with BeforeAndAfterAll {
+  override def beforeAll(): Unit = {
+    doBefore()
+  }
+
+  override def afterAll(): Unit = {
+    doAfter()
+  }
+
+  val config = ConfigFactory.parseString(
+    s"""|akka.contrib.persistence.mongodb.mongo {
+        | mongouri = "mongodb://localhost:$embedConnectionPort/$embedDB"
+        | database = "User-Specified-Database"
+        |}
+      """.stripMargin)
+
+  override def embedDB = "admin"
+
+  "Persistence store database config" should "be User-Specified-Database" in withConfig(config, "akka-contrib-mongodb-persistence-journal") { case (actorSystem, c) =>
+    val underTest = new CasbahMongoDriver(actorSystem, c)
+    assertResult("User-Specified-Database")(underTest.db.name)
+    ()
+  }
+}

--- a/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistence.scala
+++ b/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistence.scala
@@ -104,6 +104,7 @@ abstract class MongoPersistenceDriver(as: ActorSystem, config: Config) {
                       TIMESTAMP -> -1)(concurrent.ExecutionContext.Implicits.global)
   }
 
+  def databaseName = settings.Database
   def snapsCollectionName = settings.SnapsCollection
   def snapsIndexName = settings.SnapsIndex
   def snapsWriteSafety: WriteSafety = settings.SnapsWriteConcern

--- a/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistenceExtension.scala
+++ b/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistenceExtension.scala
@@ -82,6 +82,8 @@ class MongoSettings(val config: Config) {
       }) getOrElse s"mongodb://$Urls/$DbName"
   }
 
+  val Database = Try(config.getString("database")).toOption
+
   val JournalCollection = config.getString("journal-collection")
   val JournalIndex = config.getString("journal-index")
   val JournalWriteConcern = config.getString("journal-write-concern")

--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceExtension.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceExtension.scala
@@ -147,7 +147,7 @@ class RxMongoDriver(system: ActorSystem, config: Config) extends MongoPersistenc
 
   private[mongodb] def closeConnections(): Unit = driver.close()
 
-  private[mongodb] def dbName: String = parsedMongoUri.db.getOrElse(DEFAULT_DB_NAME)
+  private[mongodb] def dbName: String = databaseName.getOrElse(parsedMongoUri.db.getOrElse(DEFAULT_DB_NAME))
   private[mongodb] def db = connection(dbName)(system.dispatcher)
 
   private[mongodb] override def collection(name: String) = db[BSONCollection](name)

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoDatabaseConfigSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoDatabaseConfigSpec.scala
@@ -1,0 +1,39 @@
+package akka.contrib.persistence.mongodb
+
+import akka.contrib.persistence.mongodb.ConfigLoanFixture._
+import com.typesafe.config.ConfigFactory
+import org.junit.runner.RunWith
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.junit.JUnitRunner
+
+/**
+  * RxMongo database config spec
+  * @author  wanglei
+  * @since   15-11-28
+  * @version 1.0
+  */
+@RunWith(classOf[JUnitRunner])
+class RxMongoDatabaseConfigSpec extends BaseUnitTest with EmbeddedMongo with BeforeAndAfterAll {
+  override def beforeAll(): Unit = {
+    doBefore()
+  }
+
+  override def afterAll(): Unit = {
+    doAfter()
+  }
+
+  val config = ConfigFactory.parseString(
+    s"""|akka.contrib.persistence.mongodb.mongo {
+        | mongouri = "mongodb://localhost:$embedConnectionPort/$embedDB"
+        | database = "User-Specified-Database"
+        |}
+      """.stripMargin)
+
+  override def embedDB = "admin"
+
+  "Persistence store database config" should "be User-Specified-Database" in withConfig(config, "akka-contrib-mongodb-persistence-journal") { case (actorSystem, c) =>
+    val underTest = new RxMongoDriver(actorSystem, c)
+    assertResult("User-Specified-Database")(underTest.db.name)
+    ()
+  }
+}


### PR DESCRIPTION
Sorry , I don't know how to squash the original pr commits, so I create a new one.
Related to <pr 67><https://github.com/scullxbones/akka-persistence-mongo/pull/67>