### PR TITLE
Add index for max sequence query

### DIFF
--- a/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceExtension.scala
+++ b/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceExtension.scala
@@ -93,10 +93,10 @@ class CasbahMongoDriver(system: ActorSystem, config: Config) extends MongoPersis
   private[mongodb] def journalWriteConcern: WriteConcern = toWriteConcern(journalWriteSafety,journalWTimeout,journalFsync)
   private[mongodb] def snapsWriteConcern: WriteConcern = toWriteConcern(snapsWriteSafety,snapsWTimeout,snapsFsync)
 
-  private[mongodb] override def ensureUniqueIndex(collection: C, indexName: String, keys: (String,Int)*)(implicit ec: ExecutionContext): MongoCollection = {
-    collection.createIndex(
-      MongoDBObject(keys :_*),
-      MongoDBObject("unique" -> true, "name" -> indexName))
+  private[mongodb] override def ensureIndex(indexName: String, unique: Boolean, fields: (String,Int)*)(implicit ec: ExecutionContext): C => C = { collection =>
+   collection.createIndex(
+      MongoDBObject(fields :_*),
+      MongoDBObject("unique" -> unique, "name" -> indexName))
     collection
   }
 

--- a/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournaller.scala
+++ b/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournaller.scala
@@ -25,6 +25,7 @@ class CasbahPersistenceJournaller(driver: CasbahMongoDriver) extends MongoPersis
 
   private[mongodb] def journalRange(pid: String, from: Long, to: Long)(implicit ec: ExecutionContext): Iterator[Event] =
     journal.find(journalRangeQuery(pid, from, to))
+            .sort(MongoDBObject(FROM -> 1))
            .flatMap(_.getAs[MongoDBList](EVENTS))
            .flatMap(lst => lst.collect { case x:DBObject => x })
            .filter(dbo => dbo.getAs[Long](SEQUENCE_NUMBER).exists(sn => sn >= from && sn <= to))

--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoJournaller.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoJournaller.scala
@@ -30,6 +30,7 @@ class RxMongoJournaller(driver: RxMongoDriver) extends MongoPersistenceJournalli
 
   private[mongodb] def journalRange(pid: String, from: Long, to: Long)(implicit ec: ExecutionContext) = {
     val enum = journal.find(journalRangeQuery(pid, from, to))
+                      .sort(BSONDocument(FROM -> 1))
                       .projection(BSONDocument(EVENTS -> 1))
                       .cursor[BSONDocument]()
                       .enumerate()

--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceExtension.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceExtension.scala
@@ -164,12 +164,12 @@ class RxMongoDriver(system: ActorSystem, config: Config) extends MongoPersistenc
   private[mongodb] def journalWriteConcern: WriteConcern = toWriteConcern(journalWriteSafety,journalWTimeout,journalFsync)
   private[mongodb] def snapsWriteConcern: WriteConcern = toWriteConcern(snapsWriteSafety,snapsWTimeout,snapsFsync)
 
-  private[mongodb] override def ensureUniqueIndex(collection: C, indexName: String, keys: (String,Int)*)(implicit ec: ExecutionContext) = {
+  private[mongodb] override def ensureIndex(indexName: String, unique: Boolean, keys: (String,Int)*)(implicit ec: ExecutionContext) = { collection =>
     val ky = keys.toSeq.map{ case (f,o) => f -> (if (o > 0) IndexType.Ascending else IndexType.Descending)}
     collection.indexesManager.ensure(new Index(
       key = ky,
       background = true,
-      unique = true,
+      unique = unique,
       name = Some(indexName)))
     collection
   }


### PR DESCRIPTION
* Add index on PID asc, TO desc for max sq
* Necessary for very large journals to avoid mongo inmem sort
* Restructure to make it easier to add indices in future

To address issue #79 