### PR TITLE
Update journalRangeQuery - CasbahPersistenceJournaller

### DIFF
--- a/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournaller.scala
+++ b/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournaller.scala
@@ -18,7 +18,7 @@ class CasbahPersistenceJournaller(driver: CasbahMongoDriver) extends MongoPersis
   private[this] lazy val writeConcern = driver.journalWriteConcern
 
   private[this] def journalRangeQuery(pid: String, from: Long, to: Long): DBObject =
-    (PROCESSOR_ID $eq pid) ++ (FROM $gte from $lte to)
+    (PROCESSOR_ID $eq pid) ++ (FROM $lte to) ++ (TO $gte fromSeq)
 
   private[this] def journal(implicit ec: ExecutionContext) = driver.journal
   private[this] def realtime(implicit ec: ExecutionContext) = driver.realtime

--- a/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournaller.scala
+++ b/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournaller.scala
@@ -18,7 +18,7 @@ class CasbahPersistenceJournaller(driver: CasbahMongoDriver) extends MongoPersis
   private[this] lazy val writeConcern = driver.journalWriteConcern
 
   private[this] def journalRangeQuery(pid: String, from: Long, to: Long): DBObject =
-    (PROCESSOR_ID $eq pid) ++ (FROM $lte to) ++ (TO $gte fromSeq)
+    (PROCESSOR_ID $eq pid) ++ (FROM $lte to) ++ (TO $gte from)
 
   private[this] def journal(implicit ec: ExecutionContext) = driver.journal
   private[this] def realtime(implicit ec: ExecutionContext) = driver.realtime

--- a/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournaller.scala
+++ b/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournaller.scala
@@ -18,7 +18,7 @@ class CasbahPersistenceJournaller(driver: CasbahMongoDriver) extends MongoPersis
   private[this] lazy val writeConcern = driver.journalWriteConcern
 
   private[this] def journalRangeQuery(pid: String, from: Long, to: Long): DBObject =
-    (PROCESSOR_ID $eq pid) ++ (FROM $gte from) ++ (FROM $lte to)
+    (PROCESSOR_ID $eq pid) ++ (FROM $gte from $lte to)
 
   private[this] def journal(implicit ec: ExecutionContext) = driver.journal
   private[this] def realtime(implicit ec: ExecutionContext) = driver.realtime


### PR DESCRIPTION
As we've seen in our mongo log, the stated query seems to override the second parameter:
```
QUERY    [conn1341] getmore database.events query: { pid: "Type", from: { $lte: 957495 } } cursorid: ...
```
The proposed query looks like the corresponding example in the mongodb-API:
http://api.mongodb.org/scala/casbah/2.0/tutorial.html , 2.2.6.1, very last example.