### PR TITLE
Update journalRangeQuery - CasbahPersistenceReadJournaller

### DIFF
--- a/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceReadJournaller.scala
+++ b/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceReadJournaller.scala
@@ -67,7 +67,7 @@ class CurrentEventsByPersistenceId(val driver: CasbahMongoDriver, persistenceId:
 
   override protected def initialCursor: Stream[Event] =
     driver.journal
-      .find((PROCESSOR_ID $eq persistenceId) ++ (FROM $gte fromSeq) ++ (FROM $lte toSeq))
+      .find((PROCESSOR_ID $eq persistenceId) ++ (FROM $gte fromSeq $lte toSeq))
       .sort(MongoDBObject(PROCESSOR_ID -> 1, FROM -> 1))
       .toStream
       .flatMap(_.getAs[MongoDBList](EVENTS))

--- a/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceReadJournaller.scala
+++ b/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceReadJournaller.scala
@@ -67,7 +67,7 @@ class CurrentEventsByPersistenceId(val driver: CasbahMongoDriver, persistenceId:
 
   override protected def initialCursor: Stream[Event] =
     driver.journal
-      .find((PROCESSOR_ID $eq persistenceId) ++ (FROM $gte fromSeq $lte toSeq))
+      .find((PROCESSOR_ID $eq persistenceId) ++ (FROM $lte toSeq) ++ (TO $gte fromSeq))
       .sort(MongoDBObject(PROCESSOR_ID -> 1, FROM -> 1))
       .toStream
       .flatMap(_.getAs[MongoDBList](EVENTS))


### PR DESCRIPTION
As we've seen in our mongo log, the stated query seems to override the second parameter:
```
QUERY    [conn1341] getmore database.events query: { pid: "Type", from: { $lte: 957495 } } cursorid: ...
```
The proposed query looks like the corresponding example in the mongodb-API:
http://api.mongodb.org/scala/casbah/2.0/tutorial.html , 2.2.6.1, very last example.