### PR TITLE
Suffix collection names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ target/
 
 # Eclipse
 .cache
+.cache-main
+.cache-tests
 .classpath
 .project
 .scala_dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - docker run -d -p $MONGODB_AUTH_PORT:27017 scullxbones/mongodb:$MONGODB_VERSION --auth $STORAGE_ENGINE
   - docker ps -a
 before_script:
-  - sleep 3
+  - sleep 15
   - docker exec $(docker ps -a | grep -e "--auth" | awk '{print $1;}') mongo admin --eval "db.createUser({user:'admin',pwd:'password',roles:['root']});"
 script:
   - sbt ++$TRAVIS_SCALA_VERSION -Dakka.test.timefactor=5 test

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ before_script:
   - sleep 15
   - docker exec $(docker ps -a | grep -e "--auth" | awk '{print $1;}') mongo admin --eval "db.createUser({user:'admin',pwd:'password',roles:['root']});"
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION -Dakka.test.timefactor=5 test
+  - sbt ++$TRAVIS_SCALA_VERSION -Dakka.test.timefactor=10 test

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ val scalaV = "2.11.7"
 
 scalaVersion := scalaV
 
-val AkkaV = "2.4.2"
+val AkkaV = "2.4.7"
 
 val commonDeps = Seq(
   ("com.typesafe.akka"  %% "akka-persistence" % AkkaV % "provided")
@@ -26,7 +26,8 @@ val commonDeps = Seq(
   "com.typesafe.akka"         %% "akka-slf4j"               % AkkaV     % "test",
   "com.typesafe.akka"         %% "akka-testkit"             % AkkaV     % "test",
   "com.typesafe.akka"         %% "akka-persistence-tck"     % AkkaV     % "test",
-  "com.typesafe.akka"         %% "akka-cluster-sharding"    % AkkaV     % "test"
+  "com.typesafe.akka"         %% "akka-cluster-sharding"    % AkkaV     % "test",
+  "com.typesafe.scala-logging"  %% "scala-logging"  % "3.1.0"     % "test"
 )
 
 val commonSettings = Seq(
@@ -71,6 +72,7 @@ lazy val `akka-persistence-mongo-common` = (project in file("common"))
 
 lazy val `akka-persistence-mongo-casbah` = (project in file("casbah"))
   .dependsOn(`akka-persistence-mongo-common` % "test->test;compile->compile")
+  //.dependsOn(`akka-persistence-mongo-common` % "compile->compile")
   .settings(commonSettings:_*)
   .settings(
     libraryDependencies ++= Seq(
@@ -80,6 +82,7 @@ lazy val `akka-persistence-mongo-casbah` = (project in file("casbah"))
 
 lazy val `akka-persistence-mongo-rxmongo` = (project in file("rxmongo"))
   .dependsOn(`akka-persistence-mongo-common` % "test->test;compile->compile")
+  //.dependsOn(`akka-persistence-mongo-common` % "compile->compile")
   .settings(commonSettings:_*)
   .settings(
     libraryDependencies ++= Seq(

--- a/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceExtension.scala
+++ b/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceExtension.scala
@@ -54,7 +54,7 @@ class CasbahMongoDriver(system: ActorSystem, config: Config) extends MongoPersis
       }
 
     Try(j.dropIndex(MongoDBObject(PROCESSOR_ID -> 1, SEQUENCE_NUMBER -> 1, DELETED -> 1))).orElse(
-      Try(j.dropIndex(getJournalIndexName(persistenceId)))).map(
+      Try(j.dropIndex(settings.JournalIndex))).map(
         _ => logger.info("Successfully dropped legacy index")).recover {
           case e: MongoCommandException if e.getErrorMessage.startsWith("index not found with name") =>
             logger.info("Legacy index has already been dropped")

--- a/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournaller.scala
+++ b/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournaller.scala
@@ -62,7 +62,7 @@ class CasbahPersistenceJournaller(driver: CasbahMongoDriver) extends MongoPersis
   private[mongodb] override def batchAppend(writes: ISeq[AtomicWrite])(implicit ec: ExecutionContext): Future[ISeq[Try[Unit]]] = {
     val batchFuture = Future {
       if (driver.useSuffixedCollectionNames) {
-        writes.groupBy(_.persistenceId).flatMap {
+        writes.groupBy(w => driver.getSuffixFromPersistenceId(w.persistenceId)).flatMap {
           case (pid, writeSeq) => doBatchAppend(writeSeq, driver.journal(pid))
         }.to[collection.immutable.Seq]
       } else {

--- a/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournaller.scala
+++ b/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournaller.scala
@@ -62,7 +62,7 @@ class CasbahPersistenceJournaller(driver: CasbahMongoDriver) extends MongoPersis
   private[mongodb] override def batchAppend(writes: ISeq[AtomicWrite])(implicit ec: ExecutionContext): Future[ISeq[Try[Unit]]] = {
     val batchFuture = Future {
       if (driver.useSuffixedCollectionNames) {
-        writes.groupBy(w => driver.getSuffixFromPersistenceId(w.persistenceId)).flatMap {
+        writes.groupBy(_.persistenceId).flatMap {
           case (pid, writeSeq) => doBatchAppend(writeSeq, driver.journal(pid))
         }.to[collection.immutable.Seq]
       } else {

--- a/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournaller.scala
+++ b/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournaller.scala
@@ -1,3 +1,9 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 import akka.persistence._
@@ -5,7 +11,7 @@ import com.mongodb.DBObject
 import com.mongodb.casbah.Imports._
 
 import scala.annotation.tailrec
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.Try
 
 class CasbahPersistenceJournaller(driver: CasbahMongoDriver) extends MongoPersistenceJournallingApi {
@@ -23,47 +29,73 @@ class CasbahPersistenceJournaller(driver: CasbahMongoDriver) extends MongoPersis
   private[this] def clearEmptyDocumentsQuery(pid: String): DBObject =
     (PROCESSOR_ID $eq pid) ++ (EVENTS $size 0)
 
-  private[this] def journal(implicit ec: ExecutionContext) = driver.journal
+  private[this] def journal(implicit ec: ExecutionContext): MongoCollection = driver.journal
 
   private[this] def realtime(implicit ec: ExecutionContext) = driver.realtime
 
   private[this] def metadata(implicit ec: ExecutionContext) = driver.metadata
 
-  private[mongodb] def journalRange(pid: String, from: Long, to: Long)(implicit ec: ExecutionContext): Iterator[Event] =
+  private[mongodb] def journalRange(pid: String, from: Long, to: Long)(implicit ec: ExecutionContext): Iterator[Event] = {
+    val journal = driver.getJournal(pid)
     journal.find(journalRangeQuery(pid, from, to))
-            .sort(MongoDBObject(TO -> 1))
-           .flatMap(_.getAs[MongoDBList](EVENTS))
-           .flatMap(lst => lst.collect { case x:DBObject => x })
-           .filter(dbo => dbo.getAs[Long](SEQUENCE_NUMBER).exists(sn => sn >= from && sn <= to))
-           .map(driver.deserializeJournal)
+      .sort(MongoDBObject(TO -> 1))
+      .flatMap(_.getAs[MongoDBList](EVENTS))
+      .flatMap(lst => lst.collect { case x: DBObject => x })
+      .filter(dbo => dbo.getAs[Long](SEQUENCE_NUMBER).exists(sn => sn >= from && sn <= to))
+      .map(driver.deserializeJournal)
+  }
 
-  import collection.immutable.{Seq => ISeq}
-  private[mongodb] override def batchAppend(writes: ISeq[AtomicWrite])(implicit ec: ExecutionContext):Future[ISeq[Try[Unit]]] = Future {
+  import collection.immutable.{ Seq => ISeq }
+  private[this] def doBatchJournalAppend(writes: ISeq[AtomicWrite], journal: MongoCollection)(implicit ec: ExecutionContext): ISeq[Try[Unit]] = {
     val batch = writes.map(write => Try(driver.serializeJournal(Atom[DBObject](write, driver.useLegacySerialization))))
+    
     if (batch.forall(_.isSuccess)) {
       val bulk = journal.initializeOrderedBulkOperation
       batch.collect { case scala.util.Success(ser) => ser } foreach bulk.insert
       bulk.execute(writeConcern)
-
-      if(driver.realtimeEnablePersistence) {
-        val bulk2 = realtime.initializeOrderedBulkOperation
-        batch.collect { case scala.util.Success(ser) => ser } foreach bulk2.insert
-        bulk2.execute(writeConcern)
-      }
-
       batch.map(t => t.map(_ => ()))
-    } else { // degraded performance, cant batch
-      batch.map(_.map{serialized =>
+    } else { // degraded performance, can't batch
+      batch.map(_.map { serialized =>
         journal.insert(serialized)(identity, writeConcern)
-        if(driver.realtimeEnablePersistence) realtime.insert(serialized)(identity, writeConcern)
+        //if (driver.realtimeEnablePersistence) realtime.insert(serialized)(identity, writeConcern)
       }.map(_ => ()))
     }
+  }
+
+  private[this] def doBatchRealtimeAppend(writes: ISeq[AtomicWrite])(implicit ec: ExecutionContext): ISeq[Try[Unit]] = {
+    val batch = writes.map(write => Try(driver.serializeJournal(Atom[DBObject](write, driver.useLegacySerialization))))
+    if (batch.forall(_.isSuccess)) {
+      val bulk = realtime.initializeOrderedBulkOperation
+      batch.collect { case scala.util.Success(ser) => ser } foreach bulk.insert
+      bulk.execute(writeConcern)
+
+      batch.map(t => t.map(_ => ()))
+    } else { // degraded performance, can't batch
+      batch.map(_.map { serialized => realtime.insert(serialized)(identity, writeConcern) }.map(_ => ()))
+    }
+  }
+
+  private[mongodb] override def batchAppend(writes: ISeq[AtomicWrite])(implicit ec: ExecutionContext): Future[ISeq[Try[Unit]]] = {
+    val batchFuture = Future {
+      if (driver.useSuffixedCollectionNames) {
+        writes.groupBy(_.persistenceId).flatMap {
+          case (pid, writeSeq) => doBatchJournalAppend(writeSeq, driver.journal(pid))
+        }.to[collection.immutable.Seq]
+      } else {
+        doBatchJournalAppend(writes, journal)
+      }
+    }
+
+    if (driver.realtimeEnablePersistence)
+      batchFuture.flatMap { _ => Future { doBatchRealtimeAppend(writes) } }
+    else
+      batchFuture
   }
 
   private[this] def findMaxSequence(persistenceId: String, maxSequenceNr: Long)(implicit ec: ExecutionContext): Option[Long] = {
     val $match = MongoDBObject("$match" -> MongoDBObject(PROCESSOR_ID -> persistenceId, TO -> MongoDBObject("$lte" -> maxSequenceNr)))
     val $group = MongoDBObject("$group" -> MongoDBObject("_id" -> s"$$$PROCESSOR_ID", "max" -> MongoDBObject("$max" -> s"$$$TO")))
-
+    val journal = driver.getJournal(persistenceId)
     journal.aggregate($match :: $group :: Nil).results.flatMap(_.getAs[Long]("max")).headOption
   }
 
@@ -73,36 +105,35 @@ class CasbahPersistenceJournaller(driver: CasbahMongoDriver) extends MongoPersis
       MongoDBObject(PROCESSOR_ID -> persistenceId, MAX_SN -> maxSequenceNr),
       upsert = true,
       multi = false,
-      concern = driver.metadataWriteConcern
-    )
+      concern = driver.metadataWriteConcern)
   }
 
   private[mongodb] override def deleteFrom(persistenceId: String, toSequenceNr: Long)(implicit ec: ExecutionContext): Future[Unit] = Future {
+    val journal = driver.getJournal(persistenceId)
     val query = journalRangeQuery(persistenceId, 0L, toSequenceNr)
-    val update:DBObject = MongoDBObject(
+    val update: DBObject = MongoDBObject(
       "$pull" -> MongoDBObject(
         EVENTS -> MongoDBObject(
           PROCESSOR_ID -> persistenceId,
-          SEQUENCE_NUMBER -> MongoDBObject("$lte" -> toSequenceNr)
-        )),
-      "$set" -> MongoDBObject(FROM -> (toSequenceNr+1))
-    )
+          SEQUENCE_NUMBER -> MongoDBObject("$lte" -> toSequenceNr))),
+      "$set" -> MongoDBObject(FROM -> (toSequenceNr + 1)))
     val maxSn = findMaxSequence(persistenceId, toSequenceNr)
     journal.update(query, update, upsert = false, multi = true, writeConcern)
-    maxSn.foreach(setMaxSequenceMetadata(persistenceId,_))
+    maxSn.foreach(setMaxSequenceMetadata(persistenceId, _))
     journal.remove(clearEmptyDocumentsQuery(persistenceId), writeConcern)
     ()
   }
 
   private[mongodb] def maxSequenceNr(pid: String, from: Long)(implicit ec: ExecutionContext): Future[Long] = Future {
+    val journal = driver.getJournal(pid)
     val query = PROCESSOR_ID $eq pid
     val projection = MongoDBObject(TO -> 1)
     val sort = MongoDBObject(TO -> -1)
     val max = journal.find(query, projection).sort(sort).limit(1).toStream.headOption
     val maxDelete = metadata.findOne(query)
     max.flatMap(_.getAs[Long](TO))
-       .orElse(maxDelete.flatMap(_.getAs[Long](MAX_SN)))
-       .getOrElse(0L)
+      .orElse(maxDelete.flatMap(_.getAs[Long](MAX_SN)))
+      .getOrElse(0L)
   }
 
   private[mongodb] override def replayJournal(pid: String, from: Long, to: Long, max: Long)(replayCallback: PersistentRepr ⇒ Unit)(implicit ec: ExecutionContext) = Future {

--- a/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournaller.scala
+++ b/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournaller.scala
@@ -57,7 +57,6 @@ class CasbahPersistenceJournaller(driver: CasbahMongoDriver) extends MongoPersis
     } else { // degraded performance, can't batch
       batch.map(_.map { serialized =>
         journal.insert(serialized)(identity, writeConcern)
-        //if (driver.realtimeEnablePersistence) realtime.insert(serialized)(identity, writeConcern)
       }.map(_ => ()))
     }
   }

--- a/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceSnapshotter.scala
+++ b/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceSnapshotter.scala
@@ -73,8 +73,6 @@ class CasbahPersistenceSnapshotter(driver: CasbahMongoDriver) extends MongoPersi
   private[this] implicit val serialization = driver.serialization
   private[this] lazy val writeConcern = driver.snapsWriteConcern
 
-  //private[this] def snaps(implicit ec: ExecutionContext) = driver.snaps
-
   private[this] def snapQueryMaxSequenceMaxTime(pid: String, maxSeq: Long, maxTs: Long) =
     $and(PROCESSOR_ID $eq pid, SEQUENCE_NUMBER $lte maxSeq, TIMESTAMP $lte maxTs)
 

--- a/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahJournal1kSpec.scala
+++ b/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahJournal1kSpec.scala
@@ -1,3 +1,11 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 class CasbahJournal1kSpec extends Journal1kSpec(classOf[CasbahPersistenceExtension], "casbah")
+
+class CasbahSuffixJournal1kSpec extends Journal1kSpec(classOf[CasbahPersistenceExtension], "casbah", SuffixCollectionNamesTest.extendedConfig)

--- a/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahJournalLoadSpec.scala
+++ b/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahJournalLoadSpec.scala
@@ -1,3 +1,11 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 class CasbahJournalLoadSpec extends JournalLoadSpec(classOf[CasbahPersistenceExtension],"casbah")
+
+class CasbahSuffixJournalLoadSpec extends JournalLoadSpec(classOf[CasbahPersistenceExtension],"casbah", SuffixCollectionNamesTest.extendedConfig)

--- a/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahJournalSerializableSpec.scala
+++ b/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahJournalSerializableSpec.scala
@@ -1,3 +1,11 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 class CasbahJournalSerializableSpec extends JournalSerializableSpec(classOf[CasbahPersistenceExtension],"casbah")
+
+class CasbahSuffixJournalSerializableSpec extends JournalSerializableSpec(classOf[CasbahPersistenceExtension],"casbah", SuffixCollectionNamesTest.extendedConfig)

--- a/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahJournalUpgradeSpec.scala
+++ b/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahJournalUpgradeSpec.scala
@@ -1,3 +1,11 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 class CasbahJournalUpgradeSpec extends JournalUpgradeSpec(classOf[CasbahPersistenceExtension], "casbah", new CasbahMongoDriver(_,_))
+
+class CasbahSuffixJournalUpgradeSpec extends JournalUpgradeSpec(classOf[CasbahPersistenceExtension], "casbah", new CasbahMongoDriver(_,_), SuffixCollectionNamesTest.extendedConfig)

--- a/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahJournalUpgradeSpec.scala
+++ b/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahJournalUpgradeSpec.scala
@@ -7,5 +7,3 @@
 package akka.contrib.persistence.mongodb
 
 class CasbahJournalUpgradeSpec extends JournalUpgradeSpec(classOf[CasbahPersistenceExtension], "casbah", new CasbahMongoDriver(_,_))
-
-class CasbahSuffixJournalUpgradeSpec extends JournalUpgradeSpec(classOf[CasbahPersistenceExtension], "casbah", new CasbahMongoDriver(_,_), SuffixCollectionNamesTest.extendedConfig)

--- a/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournalTckSpec.scala
+++ b/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournalTckSpec.scala
@@ -1,3 +1,9 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 import org.junit.runner.RunWith
@@ -5,3 +11,6 @@ import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class CasbahPersistenceJournalTckSpec extends JournalTckSpec(classOf[CasbahPersistenceExtension], s"casbahJournalTck")
+
+@RunWith(classOf[JUnitRunner])
+class CasbahSuffixPersistenceJournalTckSpec extends JournalTckSpec(classOf[CasbahPersistenceExtension], s"casbahJournalTck", SuffixCollectionNamesTest.extendedConfig)

--- a/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournallerSpec.scala
+++ b/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournallerSpec.scala
@@ -1,3 +1,9 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 import akka.actor.ActorSystem
@@ -15,7 +21,7 @@ import scala.language.postfixOps
 @RunWith(classOf[JUnitRunner])
 class CasbahPersistenceJournallerSpec extends TestKit(ActorSystem("unit-test")) with CasbahPersistenceSpec {
 
-  import collection.immutable.{Seq => ISeq}
+  import collection.immutable.{ Seq => ISeq }
   import CasbahSerializers.Deserializer._
   import CasbahSerializers.Serializer._
   import JournallingFieldNames._
@@ -28,7 +34,7 @@ class CasbahPersistenceJournallerSpec extends TestKit(ActorSystem("unit-test")) 
     def firstEvent = dbo.as[MongoDBList](EVENTS).as[DBObject](0)
   }
 
-  def replay[A](buffer: mutable.Buffer[A]): A => Unit = (x:A) => {
+  def replay[A](buffer: mutable.Buffer[A]): A => Unit = (x: A) => {
     buffer += x
     ()
   }
@@ -37,211 +43,560 @@ class CasbahPersistenceJournallerSpec extends TestKit(ActorSystem("unit-test")) 
     val underTest = new CasbahPersistenceJournaller(driver) with MongoPersistenceJournalMetrics {
       override def driverName = "casbah"
     }
-    val records:List[PersistentRepr] = List(1L, 2L, 3L).map { sq => PersistentRepr(payload = "payload", sequenceNr = sq, persistenceId = "unit-test", manifest = "M") }
+    
+    val underExtendedTest = new CasbahPersistenceJournaller(driver) with MongoPersistenceJournalMetrics {
+      override def driverName = "casbah"
+    }
+    val records: List[PersistentRepr] = List(1L, 2L, 3L).map { sq => PersistentRepr(payload = "payload", sequenceNr = sq, persistenceId = "unit-test", manifest = "M") }
 
-    val threeAtoms: List[AtomicWrite] = ((1L to 9L) grouped 3 toList).map( block =>
-      AtomicWrite(ISeq(block.map(sn => PersistentRepr(persistenceId = "three-atoms", sequenceNr = sn, payload = "payload")) :_*))
-    )
+    val threeAtoms: List[AtomicWrite] = ((1L to 9L) grouped 3 toList).map(block =>
+      AtomicWrite(ISeq(block.map(sn => PersistentRepr(persistenceId = "three-atoms", sequenceNr = sn, payload = "payload")): _*)))
+
+    val suffix = "suffix-test"
   }
 
-  "A mongo journal implementation" should "serialize and deserialize non-confirmable data" in { new Fixture {
+  "A mongo journal implementation" should "serialize and deserialize non-confirmable data" in {
+    new Fixture {
 
-    val repr = Atom(pid = "pid", from = 1L, to = 1L, events = ISeq(Event(pid = "pid", sn = 1L, payload = "TEST")))
+      val repr = Atom(pid = "pid", from = 1L, to = 1L, events = ISeq(Event(pid = "pid", sn = 1L, payload = "TEST")))
 
-    val serialized = serializeAtom(repr)
+      val serialized = serializeAtom(repr)
 
-    val atom = serialized
+      val atom = serialized
 
-    atom.getAs[String](PROCESSOR_ID) shouldBe Some("pid")
-    atom.getAs[Long](FROM) shouldBe Some(1L)
-    atom.getAs[Long](TO) shouldBe Some(1L)
+      atom.getAs[String](PROCESSOR_ID) shouldBe Some("pid")
+      atom.getAs[Long](FROM) shouldBe Some(1L)
+      atom.getAs[Long](TO) shouldBe Some(1L)
 
-    val deserialized = deserializeDocument(serialized.firstEvent)
+      val deserialized = deserializeDocument(serialized.firstEvent)
 
-    deserialized.payload shouldBe StringPayload("TEST")
-    deserialized.pid should be("pid")
-    deserialized.sn should be(1)
-    deserialized.manifest shouldBe empty
-    deserialized.sender shouldBe empty
+      deserialized.payload shouldBe StringPayload("TEST")
+      deserialized.pid should be("pid")
+      deserialized.sn should be(1)
+      deserialized.manifest shouldBe empty
+      deserialized.sender shouldBe empty
+    }
+    ()
   }
-  () }
 
-  it should "create an appropriate index" in { new Fixture { withJournal { journal =>
-    driver.journal
+  it should "create an appropriate index" in {
+    new Fixture {
+      withJournal { journal =>
+        driver.journal
 
-    val idx = journal.getIndexInfo.filter(obj => obj("name").equals(driver.journalIndexName)).head
-    idx("unique") should ===(true)
-    idx("key") should be(MongoDBObject(PROCESSOR_ID -> 1, FROM -> 1, TO -> 1))
+        val idx = journal.getIndexInfo.filter(obj => obj("name").equals(driver.journalIndexName)).head
+        idx("unique") should ===(true)
+        idx("key") should be(MongoDBObject(PROCESSOR_ID -> 1, FROM -> 1, TO -> 1))
 
-    val seqNumIdx = journal.getIndexInfo.filter(obj => obj("name").equals(driver.journalSeqNrIndexName)).head
-    seqNumIdx.getAs[Boolean]("unique") shouldBe None
-    seqNumIdx("key") should be(MongoDBObject(PROCESSOR_ID -> 1, TO -> -1))
-  }}
-  () }
+        val seqNumIdx = journal.getIndexInfo.filter(obj => obj("name").equals(driver.journalSeqNrIndexName)).head
+        seqNumIdx.getAs[Boolean]("unique") shouldBe None
+        seqNumIdx("key") should be(MongoDBObject(PROCESSOR_ID -> 1, TO -> -1))
+      }
+    }
+    ()
+  }
 
-  it should "insert journal records" in { new Fixture { withJournal { journal =>
-    underTest.batchAppend(ISeq(AtomicWrite(records)))
+  it should "create an appropriate suffixed index" in {
+    new Fixture {
+      withSuffixedJournal(suffix) { journal =>
+        extendedDriver.journal(suffix)
 
-    journal.size should be(1)
+        // should 'retrieve' (and not 'build') the suffixed journal 
+        val journalName = extendedDriver.getJournalCollectionName(suffix)
+        extendedDriver.db.collectionExists(journalName) should be(true)
 
-    val atom = journal.head
+        val idx = journal.getIndexInfo.filter(obj => obj("name").equals(driver.getJournalIndexName(suffix))).head
+        idx("unique") should ===(true)
+        idx("key") should be(MongoDBObject(PROCESSOR_ID -> 1, FROM -> 1, TO -> 1))
 
+        val seqNumIdx = journal.getIndexInfo.filter(obj => obj("name").equals(driver.getJournalSeqNrIndexName(suffix))).head
+        seqNumIdx.getAs[Boolean]("unique") shouldBe None
+        seqNumIdx("key") should be(MongoDBObject(PROCESSOR_ID -> 1, TO -> -1))
+      }
+    }
+    ()
+  }
 
-    atom(PROCESSOR_ID) should be("unit-test")
-    atom(FROM) should be(1)
-    atom(TO) should be(3)
-    val event = atom.as[MongoDBList](EVENTS).as[DBObject](0)
-    event(PROCESSOR_ID) should be("unit-test")
-    event(SEQUENCE_NUMBER) should be(1)
-    event(PayloadKey) should be("payload")
-    event(MANIFEST) should be ("M")
-  }}
-  () }
+  it should "insert journal records" in {
+    new Fixture {
+      withJournal { journal =>
+        underTest.batchAppend(ISeq(AtomicWrite(records)))
 
-  it should "hard delete journal entries" in { new Fixture { withJournal { journal =>
-    underTest.batchAppend(ISeq(AtomicWrite(records)))
+        journal.size should be(1)
 
-    underTest.deleteFrom("unit-test", 2L)
+        val atom = journal.head
 
-    journal.size should be(1)
-    val recone = journal.head
-    recone(PROCESSOR_ID) should be("unit-test")
-    recone(FROM) should be(3)
-    recone(TO) should be(3)
-    val events = recone.as[MongoDBList](EVENTS)
-    events should have size 1
-  }}
-  () }
-  
-  it should "replay journal entries for a single atom" in { new Fixture { withJournal { journal =>
-    underTest.batchAppend(ISeq(AtomicWrite(records)))
+        atom(PROCESSOR_ID) should be("unit-test")
+        atom(FROM) should be(1)
+        atom(TO) should be(3)
+        val event = atom.as[MongoDBList](EVENTS).as[DBObject](0)
+        event(PROCESSOR_ID) should be("unit-test")
+        event(SEQUENCE_NUMBER) should be(1)
+        event(PayloadKey) should be("payload")
+        event(MANIFEST) should be("M")
+      }
+    }
+    ()
+  }
 
-    val buf = mutable.Buffer[PersistentRepr]()
-    underTest.replayJournal("unit-test", 2, 3, 10)(replay(buf)).value.get.get
-    buf should have size 2
-    buf should contain(PersistentRepr(payload = "payload", sequenceNr = 2, persistenceId = "unit-test", manifest = "M"))
-  }}
-  () }
+  it should "insert suffixed journal records" in {
+    new Fixture {
+      withAutoSuffixedJournal { drv =>
 
-  it should "replay journal entries for multiple atoms" in { new Fixture { withJournal { journal =>
-    records.foreach(r => underTest.batchAppend(ISeq(AtomicWrite(r))))
+        // should 'build' the journal suffixed by persistenceId: "unit-test"
+        underExtendedTest.batchAppend(ISeq(AtomicWrite(records)))
 
-    val buf = mutable.Buffer[PersistentRepr]()
-    underTest.replayJournal("unit-test", 2, 3, 10)(replay(buf)).value.get.get
-    buf should have size 2
-    buf should contain(PersistentRepr(payload = "payload", sequenceNr = 2, persistenceId = "unit-test", manifest = "M"))
-  }}
-  () }
+        // should 'retrieve' (and not 'build') the suffixed journal 
+        val journalName = drv.getJournalCollectionName("unit-test")
+        drv.db.collectionExists(journalName) should be(true)
+        val journal = drv.collection(journalName)
 
-  it should "replay correctly against multiple atoms - 1 atom case" in { new Fixture { withJournal { journal =>
-    underTest.batchAppend(ISeq(threeAtoms:_*))
+        journal.size should be(1)
 
-    val buf = mutable.Buffer[PersistentRepr]()
-    underTest.replayJournal("three-atoms", 2, 3, 10)(replay(buf)).value.get.get
-    val expect = (2L to 3L) map(sn => PersistentRepr(payload = "payload", sequenceNr = sn, persistenceId = "three-atoms"))
-    buf should have size 2
-    buf should contain only (expect:_*)
-  }}
-  () }
+        val atom = journal.head
 
-  it should "replay correctly against multiple atoms - 2 atom case" in { new Fixture { withJournal { journal =>
-    underTest.batchAppend(ISeq(threeAtoms:_*))
+        atom(PROCESSOR_ID) should be("unit-test")
+        atom(FROM) should be(1)
+        atom(TO) should be(3)
+        val event = atom.as[MongoDBList](EVENTS).as[DBObject](0)
+        event(PROCESSOR_ID) should be("unit-test")
+        event(SEQUENCE_NUMBER) should be(1)
+        event(PayloadKey) should be("payload")
+        event(MANIFEST) should be("M")
+      }
+    }
+    ()
+  }
 
-    val buf = mutable.Buffer[PersistentRepr]()
-    underTest.replayJournal("three-atoms", 5, 8, 10)(replay(buf)).value.get.get
-    val expect = (5L to 8L) map(sn => PersistentRepr(payload = "payload", sequenceNr = sn, persistenceId = "three-atoms"))
-    buf should have size 4
-    buf should contain only (expect:_*)
-  }}
-  () }
+  it should "hard delete journal entries" in {
+    new Fixture {
+      withJournal { journal =>
+        underTest.batchAppend(ISeq(AtomicWrite(records)))
 
-  it should "replay correctly against multiple atoms - 3 atom case" in { new Fixture { withJournal { journal =>
-    underTest.batchAppend(ISeq(threeAtoms:_*))
+        underTest.deleteFrom("unit-test", 2L)
 
-    val buf = mutable.Buffer[PersistentRepr]()
-    underTest.replayJournal("three-atoms", 3, 8, 10)(replay(buf)).value.get.get
-    val expect = (3L to 8L) map(sn => PersistentRepr(payload = "payload", sequenceNr = sn, persistenceId = "three-atoms"))
-    buf should have size 6
-    buf should contain only (expect:_*)
-  }}
-  () }
+        journal.size should be(1)
+        val recone = journal.head
+        recone(PROCESSOR_ID) should be("unit-test")
+        recone(FROM) should be(3)
+        recone(TO) should be(3)
+        val events = recone.as[MongoDBList](EVENTS)
+        events should have size 1
+      }
+    }
+    ()
+  }
 
-  it should "have a default sequence nr when journal is empty" in { new Fixture { withJournal { journal =>
-    val result = underTest.maxSequenceNr("unit-test", 5).value.get.get
-    result should be (0)
-  }}
-  () }
+  it should "hard delete suffixed journal entries" in {
+    new Fixture {
+      withAutoSuffixedJournal { drv =>
+        underExtendedTest.batchAppend(ISeq(AtomicWrite(records)))
 
-  it should "calculate the max sequence nr" in { new Fixture { withJournal { journal =>
-    underTest.batchAppend(ISeq(AtomicWrite(records)))
+        underExtendedTest.deleteFrom("unit-test", 2L)
 
-    val result = underTest.maxSequenceNr("unit-test", 2).value.get.get
-    result should be (3)
-  }}
-  () }
+        val journalName = drv.getJournalCollectionName("unit-test")
+        drv.db.collectionExists(journalName) should be(true)
+        val journal = drv.collection(journalName)
 
-  it should "support BSON payloads as MongoDBObjects" in { new Fixture { withJournal { journal =>
-    val documents = List(1L,2L,3L).map(sn => PersistentRepr(persistenceId = "unit-test", sequenceNr = sn, payload = MongoDBObject("foo" -> "bar", "baz" -> 1)))
-    underTest.batchAppend(ISeq(AtomicWrite(documents)))
-    val results = journal.find().limit(1)
-      .one()
-      .as[MongoDBList](EVENTS).collect({case x:DBObject => x})
+        journal.size should be(1)
+        val recone = journal.head
+        recone(PROCESSOR_ID) should be("unit-test")
+        recone(FROM) should be(3)
+        recone(TO) should be(3)
+        val events = recone.as[MongoDBList](EVENTS)
+        events should have size 1
+      }
+    }
+    ()
+  }
 
-    val first = results.head
-    first.getAs[String](PROCESSOR_ID) shouldBe Option("unit-test")
-    first.getAs[Long](SEQUENCE_NUMBER) shouldBe Option(1)
-    first.getAs[String](TYPE) shouldBe Option("bson")
-    val payload = first.as[MongoDBObject](PayloadKey)
-    payload.getAs[String]("foo") shouldBe Option("bar")
-    payload.getAs[Int]("baz") shouldBe Option(1)
-  }}
-  () }
+  it should "replay journal entries for a single atom" in {
+    new Fixture {
+      withJournal { journal =>
+        underTest.batchAppend(ISeq(AtomicWrite(records)))
+
+        val buf = mutable.Buffer[PersistentRepr]()
+        underTest.replayJournal("unit-test", 2, 3, 10)(replay(buf)).value.get.get
+        buf should have size 2
+        buf should contain(PersistentRepr(payload = "payload", sequenceNr = 2, persistenceId = "unit-test", manifest = "M"))
+      }
+    }
+    ()
+  }
+
+  it should "replay suffixed journal entries for a single atom" in {
+    new Fixture {
+      withAutoSuffixedJournal { drv =>
+        underExtendedTest.batchAppend(ISeq(AtomicWrite(records)))
+
+        val journalName = drv.getJournalCollectionName("unit-test")
+        drv.db.collectionExists(journalName) should be(true)
+        val journal = drv.collection(journalName)
+
+        val buf = mutable.Buffer[PersistentRepr]()
+        underExtendedTest.replayJournal("unit-test", 2, 3, 10)(replay(buf)).value.get.get
+        buf should have size 2
+        buf should contain(PersistentRepr(payload = "payload", sequenceNr = 2, persistenceId = "unit-test", manifest = "M"))
+      }
+    }
+    ()
+  }
+
+  it should "replay journal entries for multiple atoms" in {
+    new Fixture {
+      withJournal { journal =>
+        records.foreach(r => underTest.batchAppend(ISeq(AtomicWrite(r))))
+
+        val buf = mutable.Buffer[PersistentRepr]()
+        underTest.replayJournal("unit-test", 2, 3, 10)(replay(buf)).value.get.get
+        buf should have size 2
+        buf should contain(PersistentRepr(payload = "payload", sequenceNr = 2, persistenceId = "unit-test", manifest = "M"))
+      }
+    }
+    ()
+  }
+
+  it should "replay suffixed journal entries for multiple atoms" in {
+    new Fixture {
+      withAutoSuffixedJournal { drv =>
+        records.foreach(r => underExtendedTest.batchAppend(ISeq(AtomicWrite(r))))
+
+        val journalName = drv.getJournalCollectionName("unit-test")
+        drv.db.collectionExists(journalName) should be(true)
+        val journal = drv.collection(journalName)
+
+        val buf = mutable.Buffer[PersistentRepr]()
+        underExtendedTest.replayJournal("unit-test", 2, 3, 10)(replay(buf)).value.get.get
+        buf should have size 2
+        buf should contain(PersistentRepr(payload = "payload", sequenceNr = 2, persistenceId = "unit-test", manifest = "M"))
+      }
+    }
+    ()
+  }
+
+  it should "replay correctly against multiple atoms - 1 atom case" in {
+    new Fixture {
+      withJournal { journal =>
+        underTest.batchAppend(ISeq(threeAtoms: _*))
+
+        val buf = mutable.Buffer[PersistentRepr]()
+        underTest.replayJournal("three-atoms", 2, 3, 10)(replay(buf)).value.get.get
+        val expect = (2L to 3L) map (sn => PersistentRepr(payload = "payload", sequenceNr = sn, persistenceId = "three-atoms"))
+        buf should have size 2
+        buf should contain only (expect: _*)
+      }
+    }
+    ()
+  }
+
+  it should "replay correctly suffixed journal against multiple atoms - 1 atom case" in {
+    new Fixture {
+      withAutoSuffixedJournal { drv =>
+        underExtendedTest.batchAppend(ISeq(threeAtoms: _*))
+
+        val journalName = drv.getJournalCollectionName("three-atoms")
+        drv.db.collectionExists(journalName) should be(true)
+        val journal = drv.collection(journalName)
+
+        val buf = mutable.Buffer[PersistentRepr]()
+        underExtendedTest.replayJournal("three-atoms", 2, 3, 10)(replay(buf)).value.get.get
+        val expect = (2L to 3L) map (sn => PersistentRepr(payload = "payload", sequenceNr = sn, persistenceId = "three-atoms"))
+        buf should have size 2
+        buf should contain only (expect: _*)
+      }
+    }
+    ()
+  }
+
+  it should "replay correctly against multiple atoms - 2 atom case" in {
+    new Fixture {
+      withJournal { journal =>
+        underTest.batchAppend(ISeq(threeAtoms: _*))
+
+        val buf = mutable.Buffer[PersistentRepr]()
+        underTest.replayJournal("three-atoms", 5, 8, 10)(replay(buf)).value.get.get
+        val expect = (5L to 8L) map (sn => PersistentRepr(payload = "payload", sequenceNr = sn, persistenceId = "three-atoms"))
+        buf should have size 4
+        buf should contain only (expect: _*)
+      }
+    }
+    ()
+  }
+
+  it should "replay correctly suffixed journal against multiple atoms - 2 atom case" in {
+    new Fixture {
+      withAutoSuffixedJournal { drv =>
+        underExtendedTest.batchAppend(ISeq(threeAtoms: _*))
+
+        val journalName = drv.getJournalCollectionName("three-atoms")
+        drv.db.collectionExists(journalName) should be(true)
+        val journal = drv.collection(journalName)
+
+        val buf = mutable.Buffer[PersistentRepr]()
+        underExtendedTest.replayJournal("three-atoms", 5, 8, 10)(replay(buf)).value.get.get
+        val expect = (5L to 8L) map (sn => PersistentRepr(payload = "payload", sequenceNr = sn, persistenceId = "three-atoms"))
+        buf should have size 4
+        buf should contain only (expect: _*)
+      }
+    }
+    ()
+  }
+
+  it should "replay correctly against multiple atoms - 3 atom case" in {
+    new Fixture {
+      withJournal { journal =>
+        underTest.batchAppend(ISeq(threeAtoms: _*))
+
+        val buf = mutable.Buffer[PersistentRepr]()
+        underTest.replayJournal("three-atoms", 3, 8, 10)(replay(buf)).value.get.get
+        val expect = (3L to 8L) map (sn => PersistentRepr(payload = "payload", sequenceNr = sn, persistenceId = "three-atoms"))
+        buf should have size 6
+        buf should contain only (expect: _*)
+      }
+    }
+    ()
+  }
+
+  it should "replay correctly suffixed journal against multiple atoms - 3 atom case" in {
+    new Fixture {
+      withAutoSuffixedJournal { drv =>
+        underExtendedTest.batchAppend(ISeq(threeAtoms: _*))
+
+        val journalName = drv.getJournalCollectionName("three-atoms")
+        drv.db.collectionExists(journalName) should be(true)
+        val journal = drv.collection(journalName)
+
+        val buf = mutable.Buffer[PersistentRepr]()
+        underExtendedTest.replayJournal("three-atoms", 3, 8, 10)(replay(buf)).value.get.get
+        val expect = (3L to 8L) map (sn => PersistentRepr(payload = "payload", sequenceNr = sn, persistenceId = "three-atoms"))
+        buf should have size 6
+        buf should contain only (expect: _*)
+      }
+    }
+    ()
+  }
+
+  it should "have a default sequence nr when journal is empty" in {
+    new Fixture {
+      withJournal { journal =>
+        val result = underTest.maxSequenceNr("unit-test", 5).value.get.get
+        result should be(0)
+      }
+    }
+    ()
+  }
+
+  it should "have a default sequence nr when suffixed journal is empty" in {
+    new Fixture {
+      withSuffixedJournal("unit-test") { journal =>
+        val result = underExtendedTest.maxSequenceNr("unit-test", 5).value.get.get
+        result should be(0)
+      }
+    }
+    ()
+  }
+
+  it should "calculate the max sequence nr" in {
+    new Fixture {
+      withJournal { journal =>
+        underTest.batchAppend(ISeq(AtomicWrite(records)))
+
+        val result = underTest.maxSequenceNr("unit-test", 2).value.get.get
+        result should be(3)
+      }
+    }
+    ()
+  }
+
+  it should "calculate the max sequence nr for suffixed journal" in {
+    new Fixture {
+      withAutoSuffixedJournal { drv =>
+        underExtendedTest.batchAppend(ISeq(AtomicWrite(records)))
+
+        val journalName = drv.getJournalCollectionName("unit-test")
+        drv.db.collectionExists(journalName) should be(true)
+        val journal = drv.collection(journalName)
+
+        val result = underExtendedTest.maxSequenceNr("unit-test", 2).value.get.get
+        result should be(3)
+      }
+    }
+    ()
+  }
+
+  it should "support BSON payloads as MongoDBObjects" in {
+    new Fixture {
+      withJournal { journal =>
+        val documents = List(1L, 2L, 3L).map(sn => PersistentRepr(persistenceId = "unit-test", sequenceNr = sn, payload = MongoDBObject("foo" -> "bar", "baz" -> 1)))
+        underTest.batchAppend(ISeq(AtomicWrite(documents)))
+        val results = journal.find().limit(1)
+          .one()
+          .as[MongoDBList](EVENTS).collect({ case x: DBObject => x })
+
+        val first = results.head
+        first.getAs[String](PROCESSOR_ID) shouldBe Option("unit-test")
+        first.getAs[Long](SEQUENCE_NUMBER) shouldBe Option(1)
+        first.getAs[String](TYPE) shouldBe Option("bson")
+        val payload = first.as[MongoDBObject](PayloadKey)
+        payload.getAs[String]("foo") shouldBe Option("bar")
+        payload.getAs[Int]("baz") shouldBe Option(1)
+      }
+    }
+    ()
+  }
+
+  it should "support BSON payloads as MongoDBObjects in suffixed journal" in {
+    new Fixture {
+      withAutoSuffixedJournal { drv =>
+        val documents = List(1L, 2L, 3L).map(sn => PersistentRepr(persistenceId = "unit-test", sequenceNr = sn, payload = MongoDBObject("foo" -> "bar", "baz" -> 1)))
+        underExtendedTest.batchAppend(ISeq(AtomicWrite(documents)))
+
+        val journalName = drv.getJournalCollectionName("unit-test")
+        drv.db.collectionExists(journalName) should be(true)
+        val journal = drv.collection(journalName)
+
+        val results = journal.find().limit(1)
+          .one()
+          .as[MongoDBList](EVENTS).collect({ case x: DBObject => x })
+
+        val first = results.head
+        first.getAs[String](PROCESSOR_ID) shouldBe Option("unit-test")
+        first.getAs[Long](SEQUENCE_NUMBER) shouldBe Option(1)
+        first.getAs[String](TYPE) shouldBe Option("bson")
+        val payload = first.as[MongoDBObject](PayloadKey)
+        payload.getAs[String]("foo") shouldBe Option("bar")
+        payload.getAs[Int]("baz") shouldBe Option(1)
+      }
+    }
+    ()
+  }
 
   import concurrent.duration._
-  it should "support Serializable w/ Manifest payloads like cluster sharding ones" in { new Fixture { withJournal {journal =>
-    val ar = system.deadLetters
-    val msg = akka.cluster.sharding.ShardCoordinator.Internal.ShardRegionRegistered(ar)
-    val withSerializedObjects = records.map(_.withPayload(msg))
-    val result =  underTest.batchAppend(ISeq(AtomicWrite(withSerializedObjects)))
+  it should "support Serializable w/ Manifest payloads like cluster sharding ones" in {
+    new Fixture {
+      withJournal { journal =>
+        val ar = system.deadLetters
+        val msg = akka.cluster.sharding.ShardCoordinator.Internal.ShardRegionRegistered(ar)
+        val withSerializedObjects = records.map(_.withPayload(msg))
+        val result = underTest.batchAppend(ISeq(AtomicWrite(withSerializedObjects)))
 
-    val writeResult = Await.result(result,5.seconds.dilated)
-    writeResult.foreach(wr => wr shouldBe 'success)
+        val writeResult = Await.result(result, 5.seconds.dilated)
+        writeResult.foreach(wr => wr shouldBe 'success)
 
-    val buf = mutable.Buffer[PersistentRepr]()
-    underTest.replayJournal("unit-test", 2, 3, 10)(replay(buf)).value.get.get
-    buf should have size 2
-    buf should contain(PersistentRepr(payload = msg, sequenceNr = 2, persistenceId = "unit-test", manifest = "M"))
+        val buf = mutable.Buffer[PersistentRepr]()
+        underTest.replayJournal("unit-test", 2, 3, 10)(replay(buf)).value.get.get
+        buf should have size 2
+        buf should contain(PersistentRepr(payload = msg, sequenceNr = 2, persistenceId = "unit-test", manifest = "M"))
 
-  }}
-  () }
+      }
+    }
+    ()
+  }
 
-  it should "support old-school Serializable payloads" in { new Fixture { withJournal {journal =>
-    val msg = system.deadLetters
-    val withSerializedObjects = records.map(_.withPayload(msg))
-    val result =  underTest.batchAppend(ISeq(AtomicWrite(withSerializedObjects)))
+  it should "support Serializable w/ Manifest payloads like cluster sharding ones in suffixed journal" in {
+    new Fixture {
+      withAutoSuffixedJournal { drv =>
+        val ar = system.deadLetters
+        val msg = akka.cluster.sharding.ShardCoordinator.Internal.ShardRegionRegistered(ar)
+        val withSerializedObjects = records.map(_.withPayload(msg))
+        val result = underExtendedTest.batchAppend(ISeq(AtomicWrite(withSerializedObjects)))
 
-    val writeResult = Await.result(result,5.seconds.dilated)
-    writeResult.foreach(wr => wr shouldBe 'success)
+        val writeResult = Await.result(result, 5.seconds.dilated)
+        writeResult.foreach(wr => wr shouldBe 'success)
 
-    val buf = mutable.Buffer[PersistentRepr]()
-    underTest.replayJournal("unit-test", 2, 3, 10)(replay(buf)).value.get.get
-    buf should have size 2
-    buf should contain(PersistentRepr(payload = msg, sequenceNr = 2, persistenceId = "unit-test", manifest = "M"))
+        val journalName = drv.getJournalCollectionName("unit-test")
+        drv.db.collectionExists(journalName) should be(true)
+        val journal = drv.collection(journalName)
 
-  }}
-  () }
+        val buf = mutable.Buffer[PersistentRepr]()
+        underExtendedTest.replayJournal("unit-test", 2, 3, 10)(replay(buf)).value.get.get
+        buf should have size 2
+        buf should contain(PersistentRepr(payload = msg, sequenceNr = 2, persistenceId = "unit-test", manifest = "M"))
 
-  it should "record metrics" in { new Fixture { withJournal {journal =>
-    underTest.batchAppend(ISeq(AtomicWrite(records)))
+      }
+    }
+    ()
+  }
 
-    val buf = mutable.Buffer[PersistentRepr]()
-    underTest.replayJournal("unit-test", 2, 3, 10)(replay(buf)).value.get.get
+  it should "support old-school Serializable payloads" in {
+    new Fixture {
+      withJournal { journal =>
+        val msg = system.deadLetters
+        val withSerializedObjects = records.map(_.withPayload(msg))
+        val result = underTest.batchAppend(ISeq(AtomicWrite(withSerializedObjects)))
 
+        val writeResult = Await.result(result, 5.seconds.dilated)
+        writeResult.foreach(wr => wr shouldBe 'success)
 
-    val registry = MongoPersistenceDriver.registry
-    registry.getTimers() should have size 4
-    registry.getTimers().keySet() should contain ("akka-persistence-mongo.journal.casbah.read.max-seq.timer")
-    registry.getTimers().get("akka-persistence-mongo.journal.casbah.read.max-seq.timer").getCount should be > 0L
-  }}
-  () }
+        val buf = mutable.Buffer[PersistentRepr]()
+        underTest.replayJournal("unit-test", 2, 3, 10)(replay(buf)).value.get.get
+        buf should have size 2
+        buf should contain(PersistentRepr(payload = msg, sequenceNr = 2, persistenceId = "unit-test", manifest = "M"))
+
+      }
+    }
+    ()
+  }
+
+  it should "support old-school Serializable payloads in suffixed journal" in {
+    new Fixture {
+      withAutoSuffixedJournal { drv =>
+        val msg = system.deadLetters
+        val withSerializedObjects = records.map(_.withPayload(msg))
+        val result = underExtendedTest.batchAppend(ISeq(AtomicWrite(withSerializedObjects)))
+
+        val writeResult = Await.result(result, 5.seconds.dilated)
+        writeResult.foreach(wr => wr shouldBe 'success)
+
+        val journalName = drv.getJournalCollectionName("unit-test")
+        drv.db.collectionExists(journalName) should be(true)
+        val journal = drv.collection(journalName)
+
+        val buf = mutable.Buffer[PersistentRepr]()
+        underExtendedTest.replayJournal("unit-test", 2, 3, 10)(replay(buf)).value.get.get
+        buf should have size 2
+        buf should contain(PersistentRepr(payload = msg, sequenceNr = 2, persistenceId = "unit-test", manifest = "M"))
+
+      }
+    }
+    ()
+  }
+
+  it should "record metrics" in {
+    new Fixture {
+      withJournal { journal =>
+        underTest.batchAppend(ISeq(AtomicWrite(records)))
+
+        val buf = mutable.Buffer[PersistentRepr]()
+        underTest.replayJournal("unit-test", 2, 3, 10)(replay(buf)).value.get.get
+
+        val registry = MongoPersistenceDriver.registry
+        registry.getTimers() should have size 4
+        registry.getTimers().keySet() should contain("akka-persistence-mongo.journal.casbah.read.max-seq.timer")
+        registry.getTimers().get("akka-persistence-mongo.journal.casbah.read.max-seq.timer").getCount should be > 0L
+      }
+    }
+    ()
+  }
+
+  it should "record metrics for suffixed journal" in {
+    new Fixture {
+      withAutoSuffixedJournal { drv =>
+        underExtendedTest.batchAppend(ISeq(AtomicWrite(records)))
+
+        val journalName = drv.getJournalCollectionName("unit-test")
+        drv.db.collectionExists(journalName) should be(true)
+        val journal = drv.collection(journalName)
+
+        val buf = mutable.Buffer[PersistentRepr]()
+        underExtendedTest.replayJournal("unit-test", 2, 3, 10)(replay(buf)).value.get.get
+
+        val registry = MongoPersistenceDriver.registry
+        registry.getTimers() should have size 4
+        registry.getTimers().keySet() should contain("akka-persistence-mongo.journal.casbah.read.max-seq.timer")
+        registry.getTimers().get("akka-persistence-mongo.journal.casbah.read.max-seq.timer").getCount should be > 0L
+      }
+    }
+    ()
+  }
 }

--- a/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournallerSpec.scala
+++ b/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournallerSpec.scala
@@ -105,11 +105,11 @@ class CasbahPersistenceJournallerSpec extends TestKit(ActorSystem("unit-test")) 
         val journalName = extendedDriver.getJournalCollectionName(suffix)
         extendedDriver.db.collectionExists(journalName) should be(true)
 
-        val idx = journal.getIndexInfo.filter(obj => obj("name").equals(driver.getJournalIndexName(suffix))).head
+        val idx = journal.getIndexInfo.filter(obj => obj("name").equals(driver.journalIndexName)).head
         idx("unique") should ===(true)
         idx("key") should be(MongoDBObject(PROCESSOR_ID -> 1, FROM -> 1, TO -> 1))
 
-        val seqNumIdx = journal.getIndexInfo.filter(obj => obj("name").equals(driver.getJournalSeqNrIndexName(suffix))).head
+        val seqNumIdx = journal.getIndexInfo.filter(obj => obj("name").equals(driver.journalSeqNrIndexName)).head
         seqNumIdx.getAs[Boolean]("unique") shouldBe None
         seqNumIdx("key") should be(MongoDBObject(PROCESSOR_ID -> 1, TO -> -1))
       }

--- a/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahPersistenceSnapshotterSpec.scala
+++ b/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahPersistenceSnapshotterSpec.scala
@@ -1,7 +1,13 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 import akka.actor.ActorSystem
-import akka.persistence.{SelectedSnapshot, SnapshotMetadata}
+import akka.persistence.{ SelectedSnapshot, SnapshotMetadata }
 import akka.serialization.SerializationExtension
 import akka.testkit.TestKit
 import com.mongodb.casbah.Imports._
@@ -20,169 +26,408 @@ class CasbahPersistenceSnapshotterSpec extends TestKit(ActorSystem("unit-test"))
 
   trait Fixture {
     val underTest = new CasbahPersistenceSnapshotter(driver)
+    val underExtendedTest = new CasbahPersistenceSnapshotter(extendedDriver)
     val records = List(10L, 20L, 30L).map { sq =>
       SelectedSnapshot(SnapshotMetadata("unit-test", sq, 10L * sq), "snapshot-data")
     } :+ SelectedSnapshot(SnapshotMetadata("unit-test", 30L, 10000L), "snapshot-data")
+
+    val suffix = "unit-test"
   }
 
-  "A mongo snapshot implementation" should "serialize and deserialize snapshots" in { new Fixture {
-    val snapshot = records.head
-    val serialized = serializeSnapshot(snapshot)
-    serialized(PROCESSOR_ID) should be("unit-test")
-    serialized(SEQUENCE_NUMBER) should be(10)
-    serialized(TIMESTAMP) should be(100)
+  "A mongo snapshot implementation" should "serialize and deserialize snapshots" in {
+    new Fixture {
+      val snapshot = records.head
+      val serialized = serializeSnapshot(snapshot)
+      serialized(PROCESSOR_ID) should be("unit-test")
+      serialized(SEQUENCE_NUMBER) should be(10)
+      serialized(TIMESTAMP) should be(100)
 
-    val deserialized = deserializeSnapshot(serialized)
-    deserialized.metadata.persistenceId should be("unit-test")
-    deserialized.metadata.sequenceNr should be(10)
-    deserialized.metadata.timestamp should be(100)
-    deserialized.snapshot should be("snapshot-data")
-  }
-  () }
-
-  it should "create an appropriate index" in { new Fixture {
-    withSnapshot { snapshot =>
-      driver.snaps
-      val idx = snapshot.getIndexInfo.filter(obj => obj("name").equals(driver.snapsIndexName)).head
-      idx("unique") should ===(true)
-      idx("key") should be(MongoDBObject(PROCESSOR_ID -> 1, SEQUENCE_NUMBER -> -1, TIMESTAMP -> -1))
+      val deserialized = deserializeSnapshot(serialized)
+      deserialized.metadata.persistenceId should be("unit-test")
+      deserialized.metadata.sequenceNr should be(10)
+      deserialized.metadata.timestamp should be(100)
+      deserialized.snapshot should be("snapshot-data")
     }
+    ()
   }
-  () }
 
-  it should "find nothing by sequence where time is earlier than first snapshot" in { new Fixture {
-    withSnapshot { snapshot =>
-      snapshot.insert(records: _*)
-
-      underTest.findYoungestSnapshotByMaxSequence("unit-test", 10, 10).value.get.get shouldBe None
-    }
-  }
-  () }
-
-  it should "find a prior sequence where time is earlier than first snapshot for the max sequence" in { new Fixture {
-    withSnapshot { snapshot =>
-      snapshot.insert(records: _*)
-
-      underTest.findYoungestSnapshotByMaxSequence("unit-test", 30, 250).value.get.get shouldBe
-        Some(SelectedSnapshot(SnapshotMetadata("unit-test", 20, 200), "snapshot-data"))
-    }
-  }
-  () }
-
-  it should "find the first snapshot by sequence where time is between the first and second snapshot" in { new Fixture {
-    withSnapshot { snapshot =>
-      snapshot.insert(records: _*)
-
-      underTest.findYoungestSnapshotByMaxSequence("unit-test", 30, 350).value.get.get shouldBe
-        Some(SelectedSnapshot(SnapshotMetadata("unit-test", 30, 300), "snapshot-data"))
-    }
-  }
-  () }
-
-  it should "find the last snapshot by sequence where time is after the second snapshot" in { new Fixture {
-    withSnapshot { snapshot =>
-      snapshot.insert(records: _*)
-
-      underTest.findYoungestSnapshotByMaxSequence("unit-test", 30, 25000).value.get.get shouldBe
-        Some(SelectedSnapshot(SnapshotMetadata("unit-test", 30, 10000), "snapshot-data"))
-    }
-  }
-  () }
-
-  it should "save a snapshot" in { new Fixture {
-    withSnapshot { snapshot =>
-
-      snapshot.insert(records: _*)
-
-      underTest.saveSnapshot(SelectedSnapshot(SnapshotMetadata("unit-test", 4, 1000), "snapshot-payload"))
-
-      val saved = snapshot.findOne(MongoDBObject(SEQUENCE_NUMBER -> 4)).get
-      saved(PROCESSOR_ID) should be("unit-test")
-      saved(SEQUENCE_NUMBER) should be(4)
-      saved(TIMESTAMP) should be(1000)
-    }
-  }
-  () }
-
-  it should "not delete non-existent snapshots" in { new Fixture {
-    withSnapshot { snapshot =>
-
-      snapshot.insert(records: _*)
-
-      snapshot.size should be(4)
-      underTest.deleteSnapshot("unit-test", 3, 0)
-      snapshot.size should be(4)
-
-    }
-  }
-  () }
-
-  it should "only delete the specified snapshot" in { new Fixture {
-    withSnapshot { snapshot =>
-
-      snapshot.insert(records: _*)
-
-      snapshot.size should be(4)
-      underTest.deleteSnapshot("unit-test", 30, 300)
-      snapshot.size should be(3)
-
-      val result = snapshot.findOne($and(SEQUENCE_NUMBER $eq 30, TIMESTAMP $eq 10000))
-      result should be('defined)
-    }
-  }
-  () }
-
-  it should "delete nothing if nothing matches the criteria" in { new Fixture {
-    withSnapshot { snapshot =>
-
-      snapshot.insert(records: _*)
-      snapshot.size should be(4)
-      underTest.deleteMatchingSnapshots("unit-test", 10, 50)
-      snapshot.size should be(4)
-
-    }
-  }
-  () }
-
-  it should "delete only what matches the criteria" in { new Fixture {
-    withSnapshot { snapshot =>
-
-      snapshot.insert(records: _*)
-      snapshot.size should be(4)
-
-      underTest.deleteMatchingSnapshots("unit-test", 30, 350)
-      snapshot.size should be(1)
-
-      snapshot.findOne($and(PROCESSOR_ID $eq "unit-test", SEQUENCE_NUMBER $eq 30, TIMESTAMP $eq 10000)) shouldBe defined
-
-    }
-  }
-  () }
-
-  it should "read legacy snapshot formats" in { new Fixture {
-    withSnapshot { snapshot =>
-      val legacies = records.map(CasbahPersistenceSnapshotter.legacySerializeSnapshot)
-      snapshot.insert(legacies: _*)
-      snapshot.size should be(4)
-
-      snapshot.foreach { dbo =>
-        deserializeSnapshot(dbo).metadata.persistenceId should be ("unit-test")
+  it should "create an appropriate index" in {
+    new Fixture {
+      withSnapshot { snapshot =>
+        driver.snaps
+        val idx = snapshot.getIndexInfo.filter(obj => obj("name").equals(driver.snapsIndexName)).head
+        idx("unique") should ===(true)
+        idx("key") should be(MongoDBObject(PROCESSOR_ID -> 1, SEQUENCE_NUMBER -> -1, TIMESTAMP -> -1))
       }
     }
+    ()
   }
-  () }
 
-  it should "read mixed snapshot formats" in { new Fixture {
-    withSnapshot { snapshot =>
-      val legacies = records.take(2).map(CasbahPersistenceSnapshotter.legacySerializeSnapshot)
-      val newVersions = records.drop(2).map(CasbahPersistenceSnapshotter.serializeSnapshot)
-      snapshot.insert(legacies ++ newVersions : _*)
-      snapshot.size should be(4)
+  it should "create an appropriate suffixed index" in {
+    new Fixture {
+      withSuffixedSnapshot(suffix) { snapshot =>
+        extendedDriver.snaps(suffix)
 
-      snapshot.foreach { dbo =>
-        deserializeSnapshot(dbo).metadata.persistenceId should be ("unit-test")
+        // should 'retrieve' (and not 'build') the suffixed snapshot 
+        val snapsName = extendedDriver.getSnapsCollectionName(suffix)
+        extendedDriver.db.collectionExists(snapsName) should be(true)
+
+        val idx = snapshot.getIndexInfo.filter(obj => obj("name").equals(driver.getSnapsIndexName(suffix))).head
+        idx("unique") should ===(true)
+        idx("key") should be(MongoDBObject(PROCESSOR_ID -> 1, SEQUENCE_NUMBER -> -1, TIMESTAMP -> -1))
       }
     }
+    ()
   }
-  () }
+
+  it should "find nothing by sequence where time is earlier than first snapshot" in {
+    new Fixture {
+      withSnapshot { snapshot =>
+        snapshot.insert(records: _*)
+
+        underTest.findYoungestSnapshotByMaxSequence("unit-test", 10, 10).value.get.get shouldBe None
+      }
+    }
+    ()
+  }
+
+  it should "find nothing by sequence where time is earlier than first suffixed snapshot" in {
+    new Fixture {
+      withSuffixedSnapshot(suffix) { snapshot =>
+        snapshot.insert(records: _*)
+
+        val snapsName = extendedDriver.getSnapsCollectionName(suffix)
+        extendedDriver.db.collectionExists(snapsName) should be(true)
+
+        underExtendedTest.findYoungestSnapshotByMaxSequence("unit-test", 10, 10).value.get.get shouldBe None
+      }
+    }
+    ()
+  }
+
+  it should "find a prior sequence where time is earlier than first snapshot for the max sequence" in {
+    new Fixture {
+      withSnapshot { snapshot =>
+        snapshot.insert(records: _*)
+
+        underTest.findYoungestSnapshotByMaxSequence("unit-test", 30, 250).value.get.get shouldBe
+          Some(SelectedSnapshot(SnapshotMetadata("unit-test", 20, 200), "snapshot-data"))
+      }
+    }
+    ()
+  }
+
+  it should "find a prior sequence where time is earlier than first suffixed snapshot for the max sequence" in {
+    new Fixture {
+      withSuffixedSnapshot(suffix) { snapshot =>
+        snapshot.insert(records: _*)
+
+        val snapsName = extendedDriver.getSnapsCollectionName(suffix)
+        extendedDriver.db.collectionExists(snapsName) should be(true)
+
+        underExtendedTest.findYoungestSnapshotByMaxSequence("unit-test", 30, 250).value.get.get shouldBe
+          Some(SelectedSnapshot(SnapshotMetadata("unit-test", 20, 200), "snapshot-data"))
+      }
+    }
+    ()
+  }
+
+  it should "find the first snapshot by sequence where time is between the first and second snapshot" in {
+    new Fixture {
+      withSnapshot { snapshot =>
+        snapshot.insert(records: _*)
+
+        underTest.findYoungestSnapshotByMaxSequence("unit-test", 30, 350).value.get.get shouldBe
+          Some(SelectedSnapshot(SnapshotMetadata("unit-test", 30, 300), "snapshot-data"))
+      }
+    }
+    ()
+  }
+
+  it should "find the first snapshot by sequence where time is between the first and second suffixed snapshot" in {
+    new Fixture {
+      withSuffixedSnapshot(suffix) { snapshot =>
+        snapshot.insert(records: _*)
+
+        val snapsName = extendedDriver.getSnapsCollectionName(suffix)
+        extendedDriver.db.collectionExists(snapsName) should be(true)
+
+        underExtendedTest.findYoungestSnapshotByMaxSequence("unit-test", 30, 350).value.get.get shouldBe
+          Some(SelectedSnapshot(SnapshotMetadata("unit-test", 30, 300), "snapshot-data"))
+      }
+    }
+    ()
+  }
+
+  it should "find the last snapshot by sequence where time is after the second snapshot" in {
+    new Fixture {
+      withSnapshot { snapshot =>
+        snapshot.insert(records: _*)
+
+        underTest.findYoungestSnapshotByMaxSequence("unit-test", 30, 25000).value.get.get shouldBe
+          Some(SelectedSnapshot(SnapshotMetadata("unit-test", 30, 10000), "snapshot-data"))
+      }
+    }
+    ()
+  }
+
+  it should "find the last snapshot by sequence where time is after the second suffixed snapshot" in {
+    new Fixture {
+      withSuffixedSnapshot(suffix) { snapshot =>
+        snapshot.insert(records: _*)
+
+        val snapsName = extendedDriver.getSnapsCollectionName(suffix)
+        extendedDriver.db.collectionExists(snapsName) should be(true)
+
+        underExtendedTest.findYoungestSnapshotByMaxSequence("unit-test", 30, 25000).value.get.get shouldBe
+          Some(SelectedSnapshot(SnapshotMetadata("unit-test", 30, 10000), "snapshot-data"))
+      }
+    }
+    ()
+  }
+
+  it should "save a snapshot" in {
+    new Fixture {
+      withSnapshot { snapshot =>
+
+        underTest.saveSnapshot(SelectedSnapshot(SnapshotMetadata("unit-test", 4, 1000), "snapshot-payload"))
+
+        val saved = snapshot.findOne(MongoDBObject(SEQUENCE_NUMBER -> 4)).get
+        saved(PROCESSOR_ID) should be("unit-test")
+        saved(SEQUENCE_NUMBER) should be(4)
+        saved(TIMESTAMP) should be(1000)
+      }
+    }
+    ()
+  }
+
+  it should "save a suffixed snapshot" in {
+    new Fixture {
+      withAutoSuffixedSnapshot { drv =>
+
+        underExtendedTest.saveSnapshot(SelectedSnapshot(SnapshotMetadata("unit-test", 4, 1000), "snapshot-payload"))
+        
+        val snapsName = drv.getSnapsCollectionName("unit-test")
+        drv.db.collectionExists(snapsName) should be(true)
+        val snapshot = drv.collection(snapsName)
+
+        val saved = snapshot.findOne(MongoDBObject(SEQUENCE_NUMBER -> 4)).get
+        saved(PROCESSOR_ID) should be("unit-test")
+        saved(SEQUENCE_NUMBER) should be(4)
+        saved(TIMESTAMP) should be(1000)
+      }
+    }
+    ()
+  }
+
+  it should "not delete non-existent snapshots" in {
+    new Fixture {
+      withSnapshot { snapshot =>
+
+        snapshot.insert(records: _*)
+
+        snapshot.size should be(4)
+        underTest.deleteSnapshot("unit-test", 3, 0)
+        snapshot.size should be(4)
+
+      }
+    }
+    ()
+  }
+
+  it should "not delete non-existent suffixed snapshots" in {
+    new Fixture {
+      withSuffixedSnapshot(suffix) { snapshot =>
+
+        snapshot.insert(records: _*)
+        
+        val snapsName = extendedDriver.getSnapsCollectionName(suffix)
+        extendedDriver.db.collectionExists(snapsName) should be(true)
+
+        snapshot.size should be(4)
+        underExtendedTest.deleteSnapshot("unit-test", 3, 0)
+        snapshot.size should be(4)
+
+      }
+    }
+    ()
+  }
+
+  it should "only delete the specified snapshot" in {
+    new Fixture {
+      withSnapshot { snapshot =>
+
+        snapshot.insert(records: _*)
+
+        snapshot.size should be(4)
+        underTest.deleteSnapshot("unit-test", 30, 300)
+        snapshot.size should be(3)
+
+        val result = snapshot.findOne($and(SEQUENCE_NUMBER $eq 30, TIMESTAMP $eq 10000))
+        result should be('defined)
+      }
+    }
+    ()
+  }
+
+  it should "only delete the specified suffixed snapshot" in {
+    new Fixture {
+      withSuffixedSnapshot(suffix) { snapshot =>
+
+        snapshot.insert(records: _*)
+        
+        val snapsName = extendedDriver.getSnapsCollectionName(suffix)
+        extendedDriver.db.collectionExists(snapsName) should be(true)
+
+        snapshot.size should be(4)
+        underExtendedTest.deleteSnapshot("unit-test", 30, 300)
+        snapshot.size should be(3)
+
+        val result = snapshot.findOne($and(SEQUENCE_NUMBER $eq 30, TIMESTAMP $eq 10000))
+        result should be('defined)
+      }
+    }
+    ()
+  }
+
+  it should "delete nothing if nothing matches the criteria" in {
+    new Fixture {
+      withSnapshot { snapshot =>
+
+        snapshot.insert(records: _*)
+        snapshot.size should be(4)
+        underTest.deleteMatchingSnapshots("unit-test", 10, 50)
+        snapshot.size should be(4)
+
+      }
+    }
+    ()
+  }
+
+  it should "delete nothing if nothing matches the criteria in suffixed snapshot" in {
+    new Fixture {
+      withSuffixedSnapshot(suffix) { snapshot =>
+
+        snapshot.insert(records: _*)
+        
+        val snapsName = extendedDriver.getSnapsCollectionName(suffix)
+        extendedDriver.db.collectionExists(snapsName) should be(true)
+        
+        snapshot.size should be(4)
+        
+        underExtendedTest.deleteMatchingSnapshots("unit-test", 10, 50)
+        snapshot.size should be(4)
+
+      }
+    }
+    ()
+  }
+
+  it should "delete only what matches the criteria" in {
+    new Fixture {
+      withSnapshot { snapshot =>
+
+        snapshot.insert(records: _*)
+        snapshot.size should be(4)
+
+        underTest.deleteMatchingSnapshots("unit-test", 30, 350)
+        snapshot.size should be(1)
+
+        snapshot.findOne($and(PROCESSOR_ID $eq "unit-test", SEQUENCE_NUMBER $eq 30, TIMESTAMP $eq 10000)) shouldBe defined
+
+      }
+    }
+    ()
+  }
+
+  it should "delete only what matches the criteria in suffixed snapshot" in {
+    new Fixture {
+      withSuffixedSnapshot(suffix) { snapshot =>
+
+        snapshot.insert(records: _*)
+        
+        val snapsName = extendedDriver.getSnapsCollectionName(suffix)
+        extendedDriver.db.collectionExists(snapsName) should be(true)
+        
+        snapshot.size should be(4)
+
+        underExtendedTest.deleteMatchingSnapshots("unit-test", 30, 350)
+        snapshot.size should be(1)
+
+        snapshot.findOne($and(PROCESSOR_ID $eq "unit-test", SEQUENCE_NUMBER $eq 30, TIMESTAMP $eq 10000)) shouldBe defined
+
+      }
+    }
+    ()
+  }
+
+  it should "read legacy snapshot formats" in {
+    new Fixture {
+      withSnapshot { snapshot =>
+        val legacies = records.map(CasbahPersistenceSnapshotter.legacySerializeSnapshot)
+        snapshot.insert(legacies: _*)
+        snapshot.size should be(4)
+
+        snapshot.foreach { dbo =>
+          deserializeSnapshot(dbo).metadata.persistenceId should be("unit-test")
+        }
+      }
+    }
+    ()
+  }
+
+  it should "read legacy suffixed snapshot formats" in {
+    new Fixture {
+      withSuffixedSnapshot(suffix) { snapshot =>
+        val legacies = records.map(CasbahPersistenceSnapshotter.legacySerializeSnapshot)
+        snapshot.insert(legacies: _*)
+        
+        val snapsName = extendedDriver.getSnapsCollectionName(suffix)
+        extendedDriver.db.collectionExists(snapsName) should be(true)
+        
+        snapshot.size should be(4)
+
+        snapshot.foreach { dbo =>
+          deserializeSnapshot(dbo).metadata.persistenceId should be("unit-test")
+        }
+      }
+    }
+    ()
+  }
+
+  it should "read mixed snapshot formats" in {
+    new Fixture {
+      withSnapshot { snapshot =>
+        val legacies = records.take(2).map(CasbahPersistenceSnapshotter.legacySerializeSnapshot)
+        val newVersions = records.drop(2).map(CasbahPersistenceSnapshotter.serializeSnapshot)
+        snapshot.insert(legacies ++ newVersions: _*)
+        snapshot.size should be(4)
+
+        snapshot.foreach { dbo =>
+          deserializeSnapshot(dbo).metadata.persistenceId should be("unit-test")
+        }
+      }
+    }
+    ()
+  }
+
+  it should "read mixed suffixed snapshot formats" in {
+    new Fixture {
+      withSuffixedSnapshot(suffix) { snapshot =>
+        val legacies = records.take(2).map(CasbahPersistenceSnapshotter.legacySerializeSnapshot)
+        val newVersions = records.drop(2).map(CasbahPersistenceSnapshotter.serializeSnapshot)
+        snapshot.insert(legacies ++ newVersions: _*)
+        
+        val snapsName = extendedDriver.getSnapsCollectionName(suffix)
+        extendedDriver.db.collectionExists(snapsName) should be(true)
+        
+        snapshot.size should be(4)
+
+        snapshot.foreach { dbo =>
+          deserializeSnapshot(dbo).metadata.persistenceId should be("unit-test")
+        }
+      }
+    }
+    ()
+  }
 }

--- a/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahPersistenceSnapshotterSpec.scala
+++ b/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahPersistenceSnapshotterSpec.scala
@@ -72,7 +72,7 @@ class CasbahPersistenceSnapshotterSpec extends TestKit(ActorSystem("unit-test"))
         val snapsName = extendedDriver.getSnapsCollectionName(suffix)
         extendedDriver.db.collectionExists(snapsName) should be(true)
 
-        val idx = snapshot.getIndexInfo.filter(obj => obj("name").equals(driver.getSnapsIndexName(suffix))).head
+        val idx = snapshot.getIndexInfo.filter(obj => obj("name").equals(driver.snapsIndexName)).head
         idx("unique") should ===(true)
         idx("key") should be(MongoDBObject(PROCESSOR_ID -> 1, SEQUENCE_NUMBER -> -1, TIMESTAMP -> -1))
       }

--- a/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahPersistenceSnapshotterTckSpec.scala
+++ b/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahPersistenceSnapshotterTckSpec.scala
@@ -1,3 +1,9 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 import org.junit.runner.RunWith
@@ -5,3 +11,7 @@ import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class CasbahPersistenceSnapshotterTckSpec extends SnapshotTckSpec(classOf[CasbahPersistenceExtension], "casbah")
+
+
+@RunWith(classOf[JUnitRunner])
+class CasbahSuffixPersistenceSnapshotterTckSpec extends SnapshotTckSpec(classOf[CasbahPersistenceExtension], "casbah", SuffixCollectionNamesTest.extendedConfig)

--- a/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahPersistenceSpec.scala
+++ b/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahPersistenceSpec.scala
@@ -1,35 +1,85 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 import akka.pattern.CircuitBreaker
 import akka.testkit.TestKit
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import scala.concurrent.duration._
 import scala.language.postfixOps
-import com.mongodb.casbah.{MongoClient, MongoCollection}
+import com.mongodb.casbah.{ MongoClient, MongoCollection }
 
-trait CasbahPersistenceSpec extends MongoPersistenceSpec[CasbahMongoDriver,MongoCollection] { self: TestKit =>
+trait CasbahPersistenceSpec extends MongoPersistenceSpec[CasbahMongoDriver, MongoCollection] { self: TestKit =>
 
-    lazy val mongoDB = MongoClient(host,noAuthPort)(embedDB)
+  lazy val mongoDB = MongoClient(host, noAuthPort)(embedDB)
 
-    override val driver = new CasbahMongoDriver(system, ConfigFactory.empty()) {
+  override val driver = new CasbahMongoDriver(system, ConfigFactory.empty()) {
+    override lazy val breaker = CircuitBreaker(system.scheduler, 0, 10 seconds, 10 seconds)
+    override def collection(name: String) = mongoDB(name)
+    override lazy val db = mongoDB
+  }
+
+  override val extendedDriver = {
+    val extendedConfig = ConfigFactory.empty()
+    .withValue("akka.contrib.persistence.mongodb.mongo.use-suffixed-collection-names", ConfigValueFactory.fromAnyRef(true))
+    .withValue("akka.contrib.persistence.mongodb.mongo.suffix-builder.class",
+        ConfigValueFactory.fromAnyRef("akka.contrib.persistence.mongodb.SuffixCollectionNamesTest"))
+    .withValue("akka.contrib.persistence.mongodb.mongo.suffix-builder.separator", ConfigValueFactory.fromAnyRef("_"))
+        
+    new CasbahMongoDriver(system, extendedConfig) {
       override lazy val breaker = CircuitBreaker(system.scheduler, 0, 10 seconds, 10 seconds)
       override def collection(name: String) = mongoDB(name)
       override lazy val db = mongoDB
     }
+  }
 
-    override def withCollection(name: String)(testCode: MongoCollection => Any) = {
-      val collection = mongoDB(name)
-      try {
-        testCode(collection)
-      } finally {
-        collection.dropCollection()
-      }
+  override def withCollection(name: String)(testCode: MongoCollection => Any) = {
+    val collection = mongoDB(name)
+    try {
+      testCode(collection)
+    } finally {
+      collection.dropCollection()
     }
+  }
 
-    override def withJournal(testCode: MongoCollection => Any) =
-      withCollection(driver.journalCollectionName)(testCode)
+  override def withJournalCollections(testCode: CasbahMongoDriver => Any) = {
+    try {
+      testCode(extendedDriver)
+      ()
+    } finally {
+      extendedDriver.getJournalCollections().foreach(_.dropCollection())
+    }
+  }
 
-    override def withSnapshot(testCode: MongoCollection => Any) =
-      withCollection(driver.snapsCollectionName)(testCode)
-  
+  override def withSnapshotCollections(testCode: CasbahMongoDriver => Any) = {
+    try {
+      testCode(extendedDriver)
+      ()
+    } finally {
+      extendedDriver.getSnapshotCollections().foreach(_.dropCollection())
+    }
+  }
+
+  override def withJournal(testCode: MongoCollection => Any) =
+    withCollection(driver.journalCollectionName)(testCode)
+
+  override def withSuffixedJournal(suffix: String)(testCode: MongoCollection => Any) =
+    withCollection(extendedDriver.getJournalCollectionName(suffix))(testCode)
+
+  override def withAutoSuffixedJournal(testCode: CasbahMongoDriver => Any) =
+    withJournalCollections(testCode)
+
+  override def withSnapshot(testCode: MongoCollection => Any) =
+    withCollection(driver.snapsCollectionName)(testCode)
+
+  override def withSuffixedSnapshot(suffix: String)(testCode: MongoCollection => Any) =
+    withCollection(extendedDriver.getSnapsCollectionName(suffix))(testCode)
+
+  override def withAutoSuffixedSnapshot(testCode: CasbahMongoDriver => Any) =
+    withSnapshotCollections(testCode)
+
 }

--- a/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahPersistenceSpec.scala
+++ b/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahPersistenceSpec.scala
@@ -25,7 +25,6 @@ trait CasbahPersistenceSpec extends MongoPersistenceSpec[CasbahMongoDriver, Mong
 
   override val extendedDriver = {
     val extendedConfig = ConfigFactory.empty()
-    .withValue("akka.contrib.persistence.mongodb.mongo.use-suffixed-collection-names", ConfigValueFactory.fromAnyRef(true))
     .withValue("akka.contrib.persistence.mongodb.mongo.suffix-builder.class",
         ConfigValueFactory.fromAnyRef("akka.contrib.persistence.mongodb.SuffixCollectionNamesTest"))
     .withValue("akka.contrib.persistence.mongodb.mongo.suffix-builder.separator", ConfigValueFactory.fromAnyRef("_"))

--- a/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahReadJournalSpec.scala
+++ b/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahReadJournalSpec.scala
@@ -1,3 +1,11 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 class CasbahReadJournalSpec extends ReadJournalSpec(classOf[CasbahPersistenceExtension], "casbah")
+
+class CasbahSuffixReadJournalSpec extends ReadJournalSpec(classOf[CasbahPersistenceExtension], "casbah", SuffixCollectionNamesTest.extendedConfig)

--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -1,3 +1,10 @@
+# 
+# Contributions:
+# Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+# ...
+#
+
+
 akka {
   contrib {
     persistence {
@@ -39,6 +46,24 @@ akka {
           }
 
           use-legacy-serialization = false
+          
+          # set to true for using suffixed collection names
+          use-suffixed-collection-names = false
+          suffix-builder {
+            # available only when use-suffixed-collection-names is true
+            
+            # This character is used as a separator before suffix in collection names
+            # If you provide a string longer than one character, its first character only will be used
+            # If you provide an empty string, the default underscore (_) character will be used
+            separator = "_"
+            
+            # extend 'akka.contrib.persistence.mongodb.CanSuffixCollectionNames' trait,
+            # override its method, and provide its complete path in the 'class' field below.
+            # Notice that the default "akka.contrib.persistence.mongodb.SuffixCollectionNames"
+            # does NOT suffix collection names as it always return an empty string
+            class = "akka.contrib.persistence.mongodb.SuffixCollectionNames"
+          }
+          
         }
       }
     }

--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -56,7 +56,7 @@ akka {
             
             # extend 'akka.contrib.persistence.mongodb.CanSuffixCollectionNames' trait,
             # override its method, and provide its complete path in the 'class' field below.
-            class = "akka.contrib.persistence.mongodb.SuffixCollectionNames"
+            class =
           }
           
         }

--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -56,7 +56,7 @@ akka {
             
             # extend 'akka.contrib.persistence.mongodb.CanSuffixCollectionNames' trait,
             # override its method, and provide its complete path in the 'class' field below.
-            class =
+            class = ""
           }
           
         }

--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -47,11 +47,8 @@ akka {
 
           use-legacy-serialization = false
           
-          # set to true for using suffixed collection names
-          use-suffixed-collection-names = false
-          suffix-builder {
-            # available only when use-suffixed-collection-names is true
-            
+          # suffixed collection names
+          suffix-builder {            
             # This character is used as a separator before suffix in collection names
             # If you provide a string longer than one character, its first character only will be used
             # If you provide an empty string, the default underscore (_) character will be used
@@ -59,8 +56,6 @@ akka {
             
             # extend 'akka.contrib.persistence.mongodb.CanSuffixCollectionNames' trait,
             # override its method, and provide its complete path in the 'class' field below.
-            # Notice that the default "akka.contrib.persistence.mongodb.SuffixCollectionNames"
-            # does NOT suffix collection names as it always return an empty string
             class = "akka.contrib.persistence.mongodb.SuffixCollectionNames"
           }
           

--- a/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistence.scala
+++ b/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistence.scala
@@ -107,7 +107,7 @@ abstract class MongoPersistenceDriver(as: ActorSystem, config: Config) {
   /**
    * retrieve suffix from persistenceId
    */
-  private[this] def getSuffixFromPersistenceId(persistenceId: String): String = suffixBuilderClassOption match {
+  private[mongodb] def getSuffixFromPersistenceId(persistenceId: String): String = suffixBuilderClassOption match {
     case Some(suffixBuilderClass) if (!suffixBuilderClass.trim.isEmpty) => {
       val builderClass = Class.forName(suffixBuilderClass)
       val builderCons = builderClass.getConstructor()
@@ -175,11 +175,10 @@ abstract class MongoPersistenceDriver(as: ActorSystem, config: Config) {
    * CAUTION: this method does NOT create the snapshot and its indexes.
    */
   private[mongodb] def getSnaps(persistenceId: String): C = collection(getSnapsCollectionName(persistenceId))
-   
+
   private[mongodb] lazy val indexes: Seq[IndexSettings] = Seq(
     IndexSettings(journalIndexName, unique = true, sparse = false, JournallingFieldNames.PROCESSOR_ID -> 1, FROM -> 1, TO -> 1),
-    IndexSettings(journalSeqNrIndexName, unique = false, sparse = false, JournallingFieldNames.PROCESSOR_ID -> 1, TO -> -1)
-  )
+    IndexSettings(journalSeqNrIndexName, unique = false, sparse = false, JournallingFieldNames.PROCESSOR_ID -> 1, TO -> -1))
 
   private[mongodb] lazy val journal: C = journal("")
 
@@ -201,7 +200,7 @@ abstract class MongoPersistenceDriver(as: ActorSystem, config: Config) {
 
   private[mongodb] def snaps(persistenceId: String): C = {
     val snapsCollection = collection(getSnapsCollectionName(persistenceId))
-    ensureIndex(snapsIndexName /*getSnapsIndexName(persistenceId)*/, unique = true, sparse = false,
+    ensureIndex(snapsIndexName /*getSnapsIndexName(persistenceId)*/ , unique = true, sparse = false,
       SnapshottingFieldNames.PROCESSOR_ID -> 1,
       SnapshottingFieldNames.SEQUENCE_NUMBER -> -1,
       TIMESTAMP -> -1)(concurrent.ExecutionContext.global)(snapsCollection)

--- a/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistence.scala
+++ b/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistence.scala
@@ -107,7 +107,7 @@ abstract class MongoPersistenceDriver(as: ActorSystem, config: Config) {
   /**
    * retrieve suffix from persistenceId
    */
-  private[mongodb] def getSuffixFromPersistenceId(persistenceId: String): String = suffixBuilderClassOption match {
+  private[this] def getSuffixFromPersistenceId(persistenceId: String): String = suffixBuilderClassOption match {
     case Some(suffixBuilderClass) if (!suffixBuilderClass.trim.isEmpty) => {
       val builderClass = Class.forName(suffixBuilderClass)
       val builderCons = builderClass.getConstructor()

--- a/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistence.scala
+++ b/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistence.scala
@@ -200,7 +200,7 @@ abstract class MongoPersistenceDriver(as: ActorSystem, config: Config) {
 
   private[mongodb] def snaps(persistenceId: String): C = {
     val snapsCollection = collection(getSnapsCollectionName(persistenceId))
-    ensureIndex(snapsIndexName /*getSnapsIndexName(persistenceId)*/ , unique = true, sparse = false,
+    ensureIndex(snapsIndexName , unique = true, sparse = false,
       SnapshottingFieldNames.PROCESSOR_ID -> 1,
       SnapshottingFieldNames.SEQUENCE_NUMBER -> -1,
       TIMESTAMP -> -1)(concurrent.ExecutionContext.global)(snapsCollection)

--- a/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistence.scala
+++ b/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistence.scala
@@ -1,10 +1,16 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 import akka.actor.ActorSystem
 import akka.contrib.persistence.mongodb.JournallingFieldNames._
 import akka.contrib.persistence.mongodb.SnapshottingFieldNames._
 import akka.pattern.CircuitBreaker
-import akka.serialization.{Serialization, SerializationExtension}
+import akka.serialization.{ Serialization, SerializationExtension }
 import com.codahale.metrics.SharedMetricRegistries
 import com.typesafe.config.Config
 import nl.grons.metrics.scala.InstrumentedBuilder
@@ -12,7 +18,7 @@ import org.slf4j.LoggerFactory
 
 import scala.concurrent.ExecutionContext
 import scala.language.implicitConversions
-import scala.util.{Success, Failure, Try}
+import scala.util.{ Success, Failure, Try }
 
 object MongoPersistenceDriver {
 
@@ -21,15 +27,15 @@ object MongoPersistenceDriver {
   case object Acknowledged extends WriteSafety
   case object Journaled extends WriteSafety
   case object ReplicaAcknowledged extends WriteSafety
-  
+
   implicit def string2WriteSafety(fromConfig: String): WriteSafety = fromConfig.toLowerCase match {
-    case "errorsignored" => throw new IllegalArgumentException("Errors ignored is no longer supported as a write safety option")
-    case "unacknowledged" => Unacknowledged
-    case "acknowledged" => Acknowledged
-    case "journaled" => Journaled
+    case "errorsignored"       => throw new IllegalArgumentException("Errors ignored is no longer supported as a write safety option")
+    case "unacknowledged"      => Unacknowledged
+    case "acknowledged"        => Acknowledged
+    case "journaled"           => Journaled
     case "replicaacknowledged" => ReplicaAcknowledged
   }
-  
+
   private[mongodb] val registry = SharedMetricRegistries.getOrCreate("mongodb")
 }
 
@@ -43,6 +49,14 @@ trait CanSerializeJournal[D] {
 
 trait CanDeserializeJournal[D] {
   def deserializeDocument(document: D)(implicit serialization: Serialization, system: ActorSystem): Event
+}
+
+trait CanSuffixCollectionNames {
+  def getSuffixFromPersistenceId(persistenceId: String): String
+}
+
+class SuffixCollectionNames() extends CanSuffixCollectionNames {
+  override def getSuffixFromPersistenceId(persistenceId: String): String = "" // does nothing by default
 }
 
 trait JournalFormats[D] extends CanSerializeJournal[D] with CanDeserializeJournal[D]
@@ -86,48 +100,150 @@ abstract class MongoPersistenceDriver(as: ActorSystem, config: Config) {
 
   private[mongodb] def cappedCollection(name: String)(implicit ec: ExecutionContext): C
 
-  private[mongodb] def ensureIndex(indexName: String, unique: Boolean, sparse: Boolean, fields: (String,Int)*)(implicit ec: ExecutionContext): C => C
+  private[mongodb] def ensureIndex(indexName: String, unique: Boolean, sparse: Boolean, fields: (String, Int)*)(implicit ec: ExecutionContext): C => C
 
   private[mongodb] def closeConnections(): Unit
 
   private[mongodb] def upgradeJournalIfNeeded(): Unit
 
-  private[mongodb] lazy val indexes: Seq[IndexSettings] = Seq(
-    IndexSettings(journalIndexName, unique = true, sparse = false, JournallingFieldNames.PROCESSOR_ID -> 1, FROM -> 1, TO -> 1),
-    IndexSettings(journalSeqNrIndexName, unique = false, sparse = false, JournallingFieldNames.PROCESSOR_ID -> 1, TO -> -1)
-  )
+  private[mongodb] def upgradeJournalIfNeeded(suffix: String): Unit
+  
 
-  private[mongodb] lazy val journal: C = {
+  /**
+   * retrieve suffix from persistenceId
+   */
+  private[this] def getSuffixFromPersistenceId(persistenceId: String): String = {
+    if (useSuffixedCollectionNames && suffixBuilderClass != null && !suffixBuilderClass.trim.isEmpty) {
+      val builderClass = Class.forName(suffixBuilderClass)
+      val builderCons = builderClass.getConstructor()
+      val builderIns = builderCons.newInstance().asInstanceOf[CanSuffixCollectionNames]
+      builderIns.getSuffixFromPersistenceId(persistenceId)
+    } else ""
+  }
+
+  /**
+   * retrieve collection from persistenceId
+   */
+  private[this] def getSuffixedCollection(persistenceId: String)(build: String => String): C = {
+    val name = build(getSuffixFromPersistenceId(persistenceId))
+    logger.debug(s"Name used to build collection is $name")
+    collection(name)
+  }
+
+  /**
+   * validate collection name by replacing each mongoDB forbidden characters by underscore character
+   */
+  private[this] def validateMongoCharacters(str: String): String = {
+    // According to mongoDB documentation,
+    // forbidden characters in mongoDB collection names (Unix) are /\. "$
+    // Forbidden characters in mongoDB collection names (Windows) are /\. "$*<>:|?    
+    val forbidden = List('/', '\\', '.', ' ', '\"', '$', '*', '<', '>', ':', '|', '?')
+
+    str.map { c => if (forbidden.contains(c)) '_' else c }
+  }
+
+  /**
+   * build name of a collection, index, etc...
+   * by appending separator and suffix to usual name in settings
+   */
+  private[this] def appendSuffixToName(nameInSettings: String)(suffix: String): String = {
+    val name = if (useSuffixedCollectionNames) {
+      suffix match {
+        case "" => nameInSettings
+        case _  => s"${nameInSettings}${suffixSeparator}${validateMongoCharacters(suffix)}"
+      }
+    } else {
+      nameInSettings
+    }
+    logger.debug(s"""Suffixed name for value "$nameInSettings" in settings and suffix "$suffix" is "$name"""")
+    name
+  }
+
+  /**
+   * Convenient methods to retrieve journal name from persistenceId
+   */
+  private[mongodb] def getJournalCollectionName(persistenceId: String): String =
+    appendSuffixToName(journalCollectionName)(getSuffixFromPersistenceId(persistenceId))
+
+  /**
+   * Convenient methods to retrieve journal index name from persistenceId
+   */
+  private[mongodb] def getJournalIndexName(persistenceId: String): String =
+    appendSuffixToName(journalIndexName)(getSuffixFromPersistenceId(persistenceId))
+
+  /**
+   * Convenient methods to retrieve journal sequence number index name from persistenceId
+   */
+  private[mongodb] def getJournalSeqNrIndexName(persistenceId: String): String =
+    appendSuffixToName(journalSeqNrIndexName)(getSuffixFromPersistenceId(persistenceId))
+
+  /**
+   * Convenient methods to retrieve snapshot name from persistenceId
+   */
+  private[mongodb] def getSnapsCollectionName(persistenceId: String): String =
+    appendSuffixToName(snapsCollectionName)(getSuffixFromPersistenceId(persistenceId))
+
+  /**
+   * Convenient methods to retrieve snapshot index name from persistenceId
+   */
+  private[mongodb] def getSnapsIndexName(persistenceId: String): String =
+    appendSuffixToName(snapsIndexName)(getSuffixFromPersistenceId(persistenceId))
+
+  /**
+   * Convenient methods to retrieve EXISTING journal collection from persistenceId.
+   * CAUTION: this method does NOT create the journal and its indexes.
+   */
+  private[mongodb] def getJournal(persistenceId: String): C = collection(getJournalCollectionName(persistenceId))
+
+  /**
+   * Convenient methods to retrieve EXISTING snapshot collection from persistenceId.
+   * CAUTION: this method does NOT create the snapshot and its indexes.
+   */
+  private[mongodb] def getSnaps(persistenceId: String): C = collection(getSnapsCollectionName(persistenceId))
+
+  private[mongodb] lazy val indexes: Seq[IndexSettings] = indexes("")
+
+  private[mongodb] def indexes(persistenceId: String): Seq[IndexSettings] = Seq(
+    IndexSettings(getJournalIndexName(persistenceId), unique = true, sparse = false, JournallingFieldNames.PROCESSOR_ID -> 1, FROM -> 1, TO -> 1),
+    IndexSettings(getJournalSeqNrIndexName(persistenceId), unique = false, sparse = false, JournallingFieldNames.PROCESSOR_ID -> 1, TO -> -1))
+
+  private[mongodb] lazy val journal: C = journal("")
+
+  private[mongodb] def journal(persistenceId: String): C = {
     if (settings.JournalAutomaticUpgrade) {
       logger.debug("Journal automatic upgrade is enabled, executing upgrade process")
-      upgradeJournalIfNeeded()
+      upgradeJournalIfNeeded(persistenceId)
       logger.debug("Journal automatic upgrade process has completed")
     }
-    val journalCollection = collection(journalCollectionName)
+    val journalCollection = collection(getJournalCollectionName(persistenceId))
 
-    indexes.foldLeft(journalCollection) { (acc, index) =>
+    indexes(persistenceId).foldLeft(journalCollection) { (acc, index) =>
       import index._
-      ensureIndex(name, unique, sparse, fields:_*)(concurrent.ExecutionContext.global)(acc)
+      ensureIndex(name, unique, sparse, fields: _*)(concurrent.ExecutionContext.global)(acc)
     }
   }
 
-  private[mongodb] lazy val snaps: C = {
-    val snapsCollection = collection(snapsCollectionName)
-    ensureIndex(snapsIndexName, unique = true, sparse = false,
-                SnapshottingFieldNames.PROCESSOR_ID -> 1,
-                SnapshottingFieldNames.SEQUENCE_NUMBER -> -1,
-                TIMESTAMP -> -1)(concurrent.ExecutionContext.global)(snapsCollection)
+  private[mongodb] lazy val snaps: C = snaps("")
+
+  private[mongodb] def snaps(persistenceId: String): C = {
+    val snapsCollection = collection(getSnapsCollectionName(persistenceId))
+    ensureIndex(getSnapsIndexName(persistenceId), unique = true, sparse = false,
+      SnapshottingFieldNames.PROCESSOR_ID -> 1,
+      SnapshottingFieldNames.SEQUENCE_NUMBER -> -1,
+      TIMESTAMP -> -1)(concurrent.ExecutionContext.global)(snapsCollection)
   }
+
   private[mongodb] lazy val realtime: C = {
     cappedCollection(realtimeCollectionName)(concurrent.ExecutionContext.global)
   }
+
   private[mongodb] val querySideDispatcher = actorSystem.dispatchers.lookup("akka-contrib-persistence-query-dispatcher")
 
   private[mongodb] lazy val metadata: C = {
     val metadataCollection = collection(metadataCollectionName)
     ensureIndex("akka_persistence_metadata_pid",
-                unique = true, sparse = true,
-                JournallingFieldNames.PROCESSOR_ID -> 1)(concurrent.ExecutionContext.global)(metadataCollection)
+      unique = true, sparse = true,
+      JournallingFieldNames.PROCESSOR_ID -> 1)(concurrent.ExecutionContext.global)(metadataCollection)
   }
 
   def databaseName = settings.Database
@@ -148,6 +264,13 @@ abstract class MongoPersistenceDriver(as: ActorSystem, config: Config) {
   def metadataCollectionName = settings.MetadataCollection
   def mongoUri = settings.MongoUri
   def useLegacySerialization = settings.UseLegacyJournalSerialization
+
+  def useSuffixedCollectionNames = settings.UseSuffixedCollectionNames
+  def suffixBuilderClass = settings.SuffixBuilderClass
+  def suffixSeparator = settings.SuffixSeparator match {
+    case str if ! str.isEmpty => validateMongoCharacters(settings.SuffixSeparator).substring(0,1)
+    case _ => "_"
+  }
 
   implicit def serialization = SerializationExtension(actorSystem)
   def deserializeJournal(dbo: D)(implicit ev: CanDeserializeJournal[D]) = ev.deserializeDocument(dbo)(serialization, actorSystem)

--- a/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistenceExtension.scala
+++ b/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistenceExtension.scala
@@ -112,7 +112,6 @@ class MongoSettings(val config: Config) {
 
   val UseLegacyJournalSerialization = config.getBoolean("use-legacy-serialization")
   
-  val UseSuffixedCollectionNames = config.getBoolean("use-suffixed-collection-names")
   val SuffixBuilderClass = config.getString("suffix-builder.class")
   val SuffixSeparator = config.getString("suffix-builder.separator")
   

--- a/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistenceExtension.scala
+++ b/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistenceExtension.scala
@@ -1,3 +1,9 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 
@@ -105,4 +111,9 @@ class MongoSettings(val config: Config) {
   val ResetTimeout = config.getDuration("breaker.timeout.reset", MILLISECONDS).millis
 
   val UseLegacyJournalSerialization = config.getBoolean("use-legacy-serialization")
+  
+  val UseSuffixedCollectionNames = config.getBoolean("use-suffixed-collection-names")
+  val SuffixBuilderClass = config.getString("suffix-builder.class")
+  val SuffixSeparator = config.getString("suffix-builder.separator")
+  
 }

--- a/common/src/main/scala/akka/contrib/persistence/mongodb/MongoReadJournal.scala
+++ b/common/src/main/scala/akka/contrib/persistence/mongodb/MongoReadJournal.scala
@@ -1,7 +1,7 @@
 package akka.contrib.persistence.mongodb
 
 import akka.NotUsed
-import akka.actor.{Actor, ActorRef, ExtendedActorSystem, Props}
+import akka.actor.{Actor, ActorRef, ExtendedActorSystem, Props, ActorLogging}
 import akka.persistence.query._
 import akka.persistence.query.javadsl.{AllPersistenceIdsQuery => JAPIQ, CurrentEventsByPersistenceIdQuery => JCEBP, CurrentPersistenceIdsQuery => JCP, EventsByPersistenceIdQuery => JEBP}
 import akka.persistence.query.scaladsl.{AllPersistenceIdsQuery, CurrentEventsByPersistenceIdQuery, CurrentPersistenceIdsQuery, EventsByPersistenceIdQuery}
@@ -194,7 +194,7 @@ trait MongoPersistenceReadJournallingApi {
   def subscribeJournalEvents(subscriber: ActorRef): Unit
 }
 
-trait SyncActorPublisher[A,Cursor] extends ActorPublisher[A] {
+trait SyncActorPublisher[A,Cursor] extends ActorPublisher[A] with ActorLogging {
   import ActorPublisherMessage._
 
   override def preStart() = {

--- a/common/src/test/scala/akka/contrib/persistence/mongodb/BaseUnitTest.scala
+++ b/common/src/test/scala/akka/contrib/persistence/mongodb/BaseUnitTest.scala
@@ -21,7 +21,7 @@ object ConfigLoanFixture {
       testCode( (actorSystem, overrides) )
     } finally {
       actorSystem.terminate()
-      Await.result(actorSystem.whenTerminated, 3.seconds)
+      Await.ready(actorSystem.whenTerminated, 3.seconds)
       ()
     }
   }

--- a/common/src/test/scala/akka/contrib/persistence/mongodb/Journal1kSpec.scala
+++ b/common/src/test/scala/akka/contrib/persistence/mongodb/Journal1kSpec.scala
@@ -1,3 +1,9 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 import akka.actor.Props
@@ -7,7 +13,7 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 
-abstract class Journal1kSpec(extensionClass: Class[_], database: String) extends BaseUnitTest with ContainerMongo with BeforeAndAfterAll with ScalaFutures {
+abstract class Journal1kSpec(extensionClass: Class[_], database: String, extendedConfig: String = "|") extends BaseUnitTest with ContainerMongo with BeforeAndAfterAll with ScalaFutures {
 
   import ConfigLoanFixture._
 
@@ -30,6 +36,7 @@ abstract class Journal1kSpec(extensionClass: Class[_], database: String) extends
     |	  # Class name of the plugin.
     |  class = "akka.contrib.persistence.mongodb.MongoSnapshots"
     |}
+    $extendedConfig
     |""".stripMargin)
 
   object Counter {

--- a/common/src/test/scala/akka/contrib/persistence/mongodb/JournalLoadSpec.scala
+++ b/common/src/test/scala/akka/contrib/persistence/mongodb/JournalLoadSpec.scala
@@ -1,3 +1,9 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 import java.util.concurrent.atomic.AtomicInteger
@@ -11,7 +17,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, Promise}
 import scala.util.{Success, Try}
 
-abstract class JournalLoadSpec(extensionClass: Class[_], database: String) extends BaseUnitTest with ContainerMongo with BeforeAndAfterAll {
+abstract class JournalLoadSpec(extensionClass: Class[_], database: String, extendedConfig: String = "|") extends BaseUnitTest with ContainerMongo with BeforeAndAfterAll {
 
   import ConfigLoanFixture._
 
@@ -34,6 +40,7 @@ abstract class JournalLoadSpec(extensionClass: Class[_], database: String) exten
     |	  # Class name of the plugin.
     |  class = "akka.contrib.persistence.mongodb.MongoSnapshots"
     |}
+    $extendedConfig
     |""".stripMargin)
 
   def actorProps(id: String, eventCount: Int, atMost: FiniteDuration = 60.seconds): Props =

--- a/common/src/test/scala/akka/contrib/persistence/mongodb/JournalSerializableSpec.scala
+++ b/common/src/test/scala/akka/contrib/persistence/mongodb/JournalSerializableSpec.scala
@@ -1,3 +1,9 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 import akka.actor.Props
@@ -48,7 +54,7 @@ class OrderIdActor extends PersistentActor {
   override def persistenceId: String = "order-id"
 }
 
-abstract class JournalSerializableSpec(extensionClass: Class[_], database: String) extends BaseUnitTest with ContainerMongo with BeforeAndAfterAll with ScalaFutures {
+abstract class JournalSerializableSpec(extensionClass: Class[_], database: String, extendedConfig: String = "|") extends BaseUnitTest with ContainerMongo with BeforeAndAfterAll with ScalaFutures {
   import ConfigLoanFixture._
 
   override def embedDB = s"serializable-spec-$database"
@@ -68,7 +74,9 @@ abstract class JournalSerializableSpec(extensionClass: Class[_], database: Strin
     |akka-contrib-mongodb-persistence-snapshot {
     |	  # Class name of the plugin.
     |  class = "akka.contrib.persistence.mongodb.MongoSnapshots"
-    }""".stripMargin)
+    }
+    $extendedConfig
+    |""".stripMargin)
 
   "A journal" should "support writing serializable events" in withConfig(config(extensionClass), "akka-contrib-mongodb-persistence-journal") { case (as,_) =>
     implicit val system = as

--- a/common/src/test/scala/akka/contrib/persistence/mongodb/JournalTckSpec.scala
+++ b/common/src/test/scala/akka/contrib/persistence/mongodb/JournalTckSpec.scala
@@ -1,3 +1,9 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 import akka.persistence.CapabilityFlag
@@ -7,7 +13,7 @@ import org.scalatest.BeforeAndAfterAll
 
 object JournalTckSpec extends ContainerMongo {
 
-  def config(extensionClass: Class[_], database: String) = ConfigFactory.parseString(s"""
+  def config(extensionClass: Class[_], database: String, extendedConfig: String = "|") = ConfigFactory.parseString(s"""
      |akka.persistence.journal.plugin = "akka-contrib-mongodb-persistence-journal"
      |akka.contrib.persistence.mongodb.mongo.driver = "${extensionClass.getName}"
      |akka.contrib.persistence.mongodb.mongo.mongouri = "mongodb://$host:$noAuthPort"
@@ -15,12 +21,14 @@ object JournalTckSpec extends ContainerMongo {
      |akka-contrib-mongodb-persistence-journal {
      |	  # Class name of the plugin.
      |  class = "akka.contrib.persistence.mongodb.MongoJournal"
-     |}""".stripMargin)
+     |}
+     $extendedConfig
+     |""".stripMargin)
 
 }
 
-abstract class JournalTckSpec(extensionClass: Class[_], dbName: String)
-  extends JournalSpec(JournalTckSpec.config(extensionClass, dbName)) with BeforeAndAfterAll {
+abstract class JournalTckSpec(extensionClass: Class[_], dbName: String, extendedConfig: String = "|")
+  extends JournalSpec(JournalTckSpec.config(extensionClass, dbName, extendedConfig)) with BeforeAndAfterAll {
 
   override def supportsRejectingNonSerializableObjects = CapabilityFlag.on()
 

--- a/common/src/test/scala/akka/contrib/persistence/mongodb/JournalUpgradeSpec.scala
+++ b/common/src/test/scala/akka/contrib/persistence/mongodb/JournalUpgradeSpec.scala
@@ -1,3 +1,9 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 import akka.actor.ActorSystem
@@ -10,7 +16,7 @@ import org.scalatest.BeforeAndAfterAll
 import collection.JavaConverters._
 import scala.util.Try
 
-abstract class JournalUpgradeSpec[D <: MongoPersistenceDriver, X <: MongoPersistenceExtension](extensionClass: Class[X], database: String, toDriver: (ActorSystem,Config) => D) extends BaseUnitTest with ContainerMongo with BeforeAndAfterAll {
+abstract class JournalUpgradeSpec[D <: MongoPersistenceDriver, X <: MongoPersistenceExtension](extensionClass: Class[X], database: String, toDriver: (ActorSystem,Config) => D, extendedConfig: String = "|") extends BaseUnitTest with ContainerMongo with BeforeAndAfterAll {
 
   import ConfigLoanFixture._
 
@@ -34,6 +40,7 @@ abstract class JournalUpgradeSpec[D <: MongoPersistenceDriver, X <: MongoPersist
     |	  # Class name of the plugin.
     |  class = "akka.contrib.persistence.mongodb.MongoSnapshots"
     |}
+    $extendedConfig
     |""".stripMargin)
 
   def configured[A](testCode: D => A) = withConfig(config(extensionClass), "akka-contrib-mongodb-persistence-journal", "upgrade-test")(toDriver.tupled andThen testCode)

--- a/common/src/test/scala/akka/contrib/persistence/mongodb/MongoPersistenceSpec.scala
+++ b/common/src/test/scala/akka/contrib/persistence/mongodb/MongoPersistenceSpec.scala
@@ -1,3 +1,9 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 import akka.testkit.TestKit
@@ -15,10 +21,24 @@ trait MongoPersistenceSpec[D,C] extends BaseUnitTest with ContainerMongo with Be
   override def afterAll() = cleanup()
 
   def driver:D
+  
+  def extendedDriver:D
 
   def withCollection(name: String)(testCode: C => Any):Any
+  
+  def withJournalCollections(testCode: D => Any):Any
+  
+  def withSnapshotCollections(testCode: D => Any):Any
 
   def withJournal(testCode: C => Any):Any
+  
+  def withSuffixedJournal(suffix: String)(testCode: C => Any):Any
+  
+  def withAutoSuffixedJournal(testCode: D => Any):Any
 
   def withSnapshot(testCode: C => Any):Any
+  
+  def withSuffixedSnapshot(suffix: String)(testCode: C => Any):Any
+  
+  def withAutoSuffixedSnapshot(testCode: D => Any):Any
 }

--- a/common/src/test/scala/akka/contrib/persistence/mongodb/ReadJournalSpec.scala
+++ b/common/src/test/scala/akka/contrib/persistence/mongodb/ReadJournalSpec.scala
@@ -1,22 +1,28 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 import akka.actor.Props
 import akka.persistence.PersistentActor
-import akka.persistence.query.{EventEnvelope, PersistenceQuery}
-import akka.stream.scaladsl.{GraphDSL, Merge, RunnableGraph, Sink}
-import akka.stream.{ActorMaterializer, ClosedShape}
+import akka.persistence.query.{ EventEnvelope, PersistenceQuery }
+import akka.stream.scaladsl.{ GraphDSL, Merge, RunnableGraph, Sink }
+import akka.stream.{ ActorMaterializer, ClosedShape }
 import akka.testkit._
-import com.mongodb.client.model.{BulkWriteOptions, InsertOneModel}
+import com.mongodb.client.model.{ BulkWriteOptions, InsertOneModel }
 import com.typesafe.config.ConfigFactory
 import org.bson.Document
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time._
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
+import org.scalatest.{ BeforeAndAfter, BeforeAndAfterAll }
 
-import scala.concurrent.{Await, Future, Promise}
+import scala.concurrent.{ Await, Future, Promise }
 import scala.util.Random
 
-abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: Class[A], dbName: String) extends BaseUnitTest with ContainerMongo with BeforeAndAfterAll with BeforeAndAfter with Eventually {
+abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: Class[A], dbName: String, extendedConfig: String = "|") extends BaseUnitTest with ContainerMongo with BeforeAndAfterAll with BeforeAndAfter with Eventually {
 
   import ConfigLoanFixture._
 
@@ -25,7 +31,13 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
   override def afterAll() = cleanup()
 
   before {
-    "akka_persistence_realtime" :: "akka_persistence_journal" :: Nil foreach(mongoClient.getDatabase(embedDB).getCollection(_).drop())
+    //"akka_persistence_realtime" :: "akka_persistence_journal" :: Nil foreach (mongoClient.getDatabase(embedDB).getCollection(_).drop())
+    val collIterator = mongoClient.getDatabase(embedDB).listCollectionNames().iterator()
+    while (collIterator.hasNext()) {
+      val name = collIterator.next
+      if (name.startsWith("akka_persistence_journal") || name.startsWith("akka_persistence_realtime"))
+      mongoClient.getDatabase(embedDB).getCollection(name).drop()
+    }
   }
 
   def config(extensionClass: Class[_]) = ConfigFactory.parseString(s"""
@@ -45,6 +57,7 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
     |  # Class name of the plugin.
     |  class = "akka.contrib.persistence.mongodb.MongoReadJournal"
     |}
+    $extendedConfig
     |""".stripMargin).withFallback(ConfigFactory.defaultReference())
 
   def props(id: String, promise: Promise[Unit]) = Props(new Persistent(id, promise))
@@ -59,7 +72,7 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
     }
 
     override def receiveCommand: Receive = {
-      case Append(s) => persist(s){str =>
+      case Append(s) => persist(s) { str =>
         events = events :+ str
         if (str == "END") {
           completed.success(())
@@ -69,286 +82,295 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
     }
   }
 
-  "A read journal" should "support the journal dump query" in withConfig(config(extensionClass), "akka-contrib-mongodb-persistence-readjournal") { case (as,_) =>
-    import concurrent.duration._
-    implicit val system = as
-    implicit val mat = ActorMaterializer()
+  "A read journal" should "support the journal dump query" in withConfig(config(extensionClass), "akka-contrib-mongodb-persistence-readjournal") {
+    case (as, _) =>
+      import concurrent.duration._
+      implicit val system = as
+      implicit val mat = ActorMaterializer()
 
-    val events = "this" :: "is" :: "just" :: "a" :: "test" :: "END" :: Nil
+      val events = "this" :: "is" :: "just" :: "a" :: "test" :: "END" :: Nil
 
-    val promise = Promise[Unit]()
-    val ar = as.actorOf(props("foo",promise))
+      val promise = Promise[Unit]()
+      val ar = as.actorOf(props("foo", promise))
 
-    events map Append.apply foreach (ar ! _)
+      events map Append.apply foreach (ar ! _)
 
-    Await.result(promise.future, 10.seconds.dilated)
+      Await.result(promise.future, 10.seconds.dilated)
 
-    val readJournal =
-      PersistenceQuery(as).readJournalFor[ScalaDslMongoReadJournal](MongoReadJournal.Identifier)
+      val readJournal =
+        PersistenceQuery(as).readJournalFor[ScalaDslMongoReadJournal](MongoReadJournal.Identifier)
 
-    val fut = readJournal.currentAllEvents().runFold(events.toSet){ (received, ee) =>
-      val asAppend = ee.event.asInstanceOf[String]
-      events should contain (asAppend)
-      received - asAppend
-    }
+      val fut = readJournal.currentAllEvents().runFold(events.toSet) { (received, ee) =>
+        val asAppend = ee.event.asInstanceOf[String]
+        events should contain(asAppend)
+        received - asAppend
+      }
 
-    Await.result(fut,10.seconds.dilated).size shouldBe 0
+      Await.result(fut, 10.seconds.dilated).size shouldBe 0
   }
 
-  it should "support the realtime journal dump query" in withConfig(config(extensionClass), "akka-contrib-mongodb-persistence-readjournal") { case (as,_) =>
-    import concurrent.duration._
-    implicit val system = as
-    implicit val mat = ActorMaterializer()
+  it should "support the realtime journal dump query" in withConfig(config(extensionClass), "akka-contrib-mongodb-persistence-readjournal") {
+    case (as, _) =>
+      import concurrent.duration._
+      implicit val system = as
+      implicit val mat = ActorMaterializer()
 
-    val events = ("this" :: "is" :: "just" :: "a" :: "test" :: "END" :: Nil) map Append.apply
+      val events = ("this" :: "is" :: "just" :: "a" :: "test" :: "END" :: Nil) map Append.apply
 
-    val promise1 = Promise[Unit]()
-    val promise2 = Promise[Unit]()
-    val ar1 = as.actorOf(props("foo",promise1))
-    val ar2 = as.actorOf(props("bar", promise2))
+      val promise1 = Promise[Unit]()
+      val promise2 = Promise[Unit]()
+      val ar1 = as.actorOf(props("foo", promise1))
+      val ar2 = as.actorOf(props("bar", promise2))
 
-    events slice(0,3) foreach (ar1 ! _)
+      events slice (0, 3) foreach (ar1 ! _)
 
+      val readJournal =
+        PersistenceQuery(as).readJournalFor[ScalaDslMongoReadJournal](MongoReadJournal.Identifier)
 
-    val readJournal =
-      PersistenceQuery(as).readJournalFor[ScalaDslMongoReadJournal](MongoReadJournal.Identifier)
+      val probe = TestProbe()
 
-    val probe = TestProbe()
+      val promise = Promise[Int]()
+      readJournal.allEvents().runFold(0) {
+        case (accum, ee) =>
+          if (accum == 4) promise.trySuccess(accum)
+          probe.ref ! ee
+          accum + 1
+      }
+      events slice (3, 6) foreach (ar2 ! _)
 
-    val promise = Promise[Int]()
-    readJournal.allEvents().runFold(0) { case (accum, ee) =>
-      if (accum == 4) promise.trySuccess(accum)
-      probe.ref ! ee
-      accum + 1
-    }
-    events slice(3,6) foreach (ar2 ! _)
+      Await.result(promise.future, 3.seconds.dilated) shouldBe 4
 
-    Await.result(promise.future, 3.seconds.dilated) shouldBe 4
-
-    probe.receiveN(events.size, 10.seconds.dilated).collect{case msg:EventEnvelope => msg.event.toString} should contain allOf("this","is","just","a","test","END")
+      probe.receiveN(events.size, 10.seconds.dilated).collect { case msg: EventEnvelope => msg.event.toString } should contain allOf ("this", "is", "just", "a", "test", "END")
   }
 
-  it should "support the current persistence ids query" in withConfig(config(extensionClass), "akka-contrib-mongodb-persistence-readjournal") { case (as,_)  =>
-    import concurrent.duration._
-    implicit val system = as
-    implicit val mat = ActorMaterializer()
+  it should "support the current persistence ids query" in withConfig(config(extensionClass), "akka-contrib-mongodb-persistence-readjournal") {
+    case (as, _) =>
+      import concurrent.duration._
+      implicit val system = as
+      implicit val mat = ActorMaterializer()
 
-    val promises = ("1" :: "2" :: "3" :: "4" :: "5" :: Nil).map(id => id -> Promise[Unit]())
-    val ars = promises.map{ case (id,p) => as.actorOf(props(id,p),s"current-persistenceId-$id") }
+      val promises = ("1" :: "2" :: "3" :: "4" :: "5" :: Nil).map(id => id -> Promise[Unit]())
+      val ars = promises.map { case (id, p) => as.actorOf(props(id, p), s"current-persistenceId-$id") }
 
-    val end = Append("END")
-    ars foreach (_ ! end)
+      val end = Append("END")
+      ars foreach (_ ! end)
 
-    implicit val ec = as.dispatcher
-    val futures = promises.map{case(_,p)=>p.future}
-    val count = Await.result(Future.fold(futures)(0){ case(cnt,_) => cnt + 1 }, 10.seconds.dilated)
-    count shouldBe 5
+      implicit val ec = as.dispatcher
+      val futures = promises.map { case (_, p) => p.future }
+      val count = Await.result(Future.fold(futures)(0) { case (cnt, _) => cnt + 1 }, 10.seconds.dilated)
+      count shouldBe 5
 
-    val readJournal =
-      PersistenceQuery(as).readJournalFor[ScalaDslMongoReadJournal](MongoReadJournal.Identifier)
+      val readJournal =
+        PersistenceQuery(as).readJournalFor[ScalaDslMongoReadJournal](MongoReadJournal.Identifier)
 
-    val fut = readJournal.currentPersistenceIds().runFold(Seq.empty[String])(_ :+ _)
+      val fut = readJournal.currentPersistenceIds().runFold(Seq.empty[String])(_ :+ _)
 
-    Await.result(fut,10.seconds.dilated) should contain allOf("1","2","3","4","5")
+      Await.result(fut, 10.seconds.dilated) should contain allOf ("1", "2", "3", "4", "5")
   }
 
-  it should "support the current persistence ids query with more than 16MB of ids" in withConfig(config(extensionClass), "akka-contrib-mongodb-persistence-readjournal") { case (as, _) =>
-    import concurrent.duration._
+  it should "support the current persistence ids query with more than 16MB of ids" in withConfig(config(extensionClass), "akka-contrib-mongodb-persistence-readjournal") {
+    case (as, _) =>
+      import concurrent.duration._
 
-    implicit val system = as
-    implicit val ec = as.dispatcher
-    implicit val mat = ActorMaterializer()
+      implicit val system = as
+      implicit val ec = as.dispatcher
+      implicit val mat = ActorMaterializer()
 
-    val alphabet = "abcdefghijklmnopqrstuvwxyz0123456789"
-    val PID_SIZE = 900
-    val EVENT_COUNT = 187 * 100
+      val alphabet = "abcdefghijklmnopqrstuvwxyz0123456789"
+      val PID_SIZE = 900
+      val EVENT_COUNT = 187 * 100
 
-    PID_SIZE * EVENT_COUNT shouldBe > (16 * 1024 * 1024)
+      PID_SIZE * EVENT_COUNT shouldBe >(16 * 1024 * 1024)
 
-    def pidGen = (0 to PID_SIZE).map(_ => alphabet.charAt(Random.nextInt(alphabet.length))).mkString
+      def pidGen = (0 to PID_SIZE).map(_ => alphabet.charAt(Random.nextInt(alphabet.length))).mkString
 
-    import collection.JavaConverters._
+      import collection.JavaConverters._
 
-    val journalCollection = mongoClient.getDatabase(embedDB).getCollection("akka_persistence_journal")
-    Stream.from(1).takeWhile(_ <= EVENT_COUNT).map{i =>
-      new Document()
-        .append(JournallingFieldNames.PROCESSOR_ID, s"$pidGen-$i")
+      val journalCollection = mongoClient.getDatabase(embedDB).getCollection("akka_persistence_journal")
+      Stream.from(1).takeWhile(_ <= EVENT_COUNT).map { i =>
+        new Document()
+          .append(JournallingFieldNames.PROCESSOR_ID, s"$pidGen-$i")
           .append(JournallingFieldNames.FROM, 0L)
           .append(JournallingFieldNames.TO, 0L)
           .append(JournallingFieldNames.VERSION, 1)
-    }.grouped(1000).foreach{ dbos =>
-      val batch = dbos.toList.map(new InsertOneModel(_)).asJava
-      journalCollection.bulkWrite(batch, new BulkWriteOptions().ordered(false).bypassDocumentValidation(true))
-      ()
-    }
-
-    mongoClient.getDatabase(embedDB).getCollection("akka_persistence_journal").count() shouldBe EVENT_COUNT
-
-    val readJournal =
-      PersistenceQuery(as).readJournalFor[ScalaDslMongoReadJournal](MongoReadJournal.Identifier)
-
-    val fut = readJournal.currentPersistenceIds().runFold(0){ case (inc,_) => inc + 1}
-    Await.result(fut,10.seconds.dilated) shouldBe EVENT_COUNT
-
-    eventually {
-      mongoClient.getDatabase(embedDB).listCollectionNames()
-        .into(new java.util.HashSet[String]()).asScala.filter(_.startsWith("persistenceids-")) should have size 0L
-    }(PatienceConfig(timeout = Span(5L, Seconds), interval = Span(500L, Millis)))
-  }
-
-  it should "support the all persistence ids query" in withConfig(config(extensionClass), "akka-contrib-mongodb-persistence-readjournal") { case (as,_)  =>
-    implicit val system = as
-    implicit val mat = ActorMaterializer()
-
-    val promises = ("1" :: "2" :: "3" :: "4" :: "5" :: Nil).map(id => id -> Promise[Unit]())
-    val ars = promises.map{ case (id,p) => as.actorOf(props(id,p)) }
-    val events = ("this" :: "is" :: "a" :: "test" :: Nil) map Append.apply
-
-    implicit val ec = as.dispatcher
-
-    val readJournal =
-    PersistenceQuery(as).readJournalFor[ScalaDslMongoReadJournal](MongoReadJournal.Identifier)
-
-
-    val probe = TestProbe()
-
-    ars slice(0,3) foreach { ar =>
-      events foreach ( ar ! _)
-    }
-
-    readJournal.allPersistenceIds().runForeach{ pid =>
-      probe.ref ! pid
-    }
-
-    ars slice(3,5) foreach { ar =>
-      events foreach ( ar ! _)
-    }
-
-    probe.receiveN(ars.size).collect{case x:String => x} should contain allOf("1","2","3","4","5")
-  }
-
-  it should "support the current events by id query" in withConfig(config(extensionClass), "akka-contrib-mongodb-persistence-readjournal") { case (as,_) =>
-    import concurrent.duration._
-    implicit val system = as
-    implicit val mat = ActorMaterializer()
-
-    val events = ("this" :: "is" :: "just" :: "a" :: "test" :: "END" :: Nil) map Append.apply
-
-    val promise = Promise[Unit]()
-    val ar = as.actorOf(props("foo",promise))
-
-    events foreach (ar ! _)
-
-    Await.result(promise.future, 10.seconds.dilated)
-
-    val readJournal =
-      PersistenceQuery(as).readJournalFor[ScalaDslMongoReadJournal](MongoReadJournal.Identifier)
-
-    val fut = readJournal.currentEventsByPersistenceId("foo",0L,2L).runFold(events.toSet){(received, ee) =>
-      val asAppend = Append(ee.event.asInstanceOf[String])
-      events should contain (asAppend)
-      received - asAppend
-    }
-
-    Await.result(fut,10.seconds.dilated).map(_.s) shouldBe Set("just","a","test","END")
-  }
-
-  it should "support the events by id query" in withConfig(config(extensionClass), "akka-contrib-mongodb-persistence-readjournal") { case (as,_) =>
-    import concurrent.duration._
-    implicit  val system = as
-    implicit val mat = ActorMaterializer()
-
-    val readJournal =
-      PersistenceQuery(as).readJournalFor[ScalaDslMongoReadJournal](MongoReadJournal.Identifier)
-
-    val promise = Promise[Unit]()
-    val ar = as.actorOf(props("foo-live", promise))
-
-    val events = ("foo" :: "bar" :: "bar2" :: Nil) map Append.apply
-
-    val probe = TestProbe()
-
-    readJournal.eventsByPersistenceId("foo-live", 2L, 3L).runForeach(probe.ref ! _)
-
-    events foreach ( ar ! _ )
-
-    probe.receiveN(2, 10.seconds.dilated).collect{case msg:EventEnvelope => msg}.toList.map(_.event) should contain allOf("bar","bar2")
-  }
-
-  it should "support the events by id query with multiple persistent actors" in withConfig(config(extensionClass), "akka-contrib-mongodb-persistence-readjournal"){ case (as, _) =>
-    import concurrent.duration._
-    implicit  val system = as
-    implicit val mat = ActorMaterializer()
-
-    val readJournal =
-      PersistenceQuery(as).readJournalFor[ScalaDslMongoReadJournal](MongoReadJournal.Identifier)
-
-    val promise = Promise[Unit]()
-    val promise2 = Promise[Unit]()
-    val ar = as.actorOf(props("foo-live-2a", promise))
-    val ar2 = as.actorOf(props("foo-live-2b", promise2))
-
-    val events = ("foo" :: "bar" :: "bar2" :: Nil) map Append.apply
-    val events2 = ("just" :: "a" :: "test" :: Nil) map Append.apply
-
-    val probe = TestProbe()
-
-    readJournal.eventsByPersistenceId("foo-live-2b", 0L, Long.MaxValue).take(events2.size.toLong).runForeach(probe.ref ! _)
-
-    events foreach ( ar ! _ )
-    events2 foreach ( ar2 ! _ )
-
-    probe.receiveN(events2.size, 10.seconds.dilated).collect{case msg:EventEnvelope => msg}.toList.map(_.event) should be(events2.map(_.s))
-  }
-
-  it should "support read 1k events from journal" in withConfig(config(extensionClass), "akka-contrib-mongodb-persistence-readjournal"){ case (as, _) =>
-    import concurrent.duration._
-    implicit val system = as
-    implicit val mat = ActorMaterializer()
-
-    val readJournal =
-      PersistenceQuery(as).readJournalFor[ScalaDslMongoReadJournal](MongoReadJournal.Identifier)
-
-    val nrOfActors = 10
-    val nrOfEvents = 100
-    val promises = (1 to nrOfActors).map(_ => Promise[Unit]()).zipWithIndex
-    val ars = promises map { case (p,idx) => system.actorOf(props(s"pid-${idx + 1}", p),s"actor-${idx + 1}")}
-    val events = (1 to nrOfEvents).map(eventId => Append.apply(s"eventd-$eventId")) :+ Append("END")
-
-    val probe = TestProbe()
-
-
-    val sources = (1 to nrOfActors) map ( nr => readJournal.eventsByPersistenceId(s"pid-$nr", 0, Long.MaxValue).take(events.size.toLong) )
-
-    val sink = Sink.actorRef(probe.ref, "complete")
-
-    val merged = GraphDSL.create(sink) { implicit b => (s) =>
-      import GraphDSL.Implicits._
-
-      val merge = b.add(Merge[EventEnvelope](sources.size))
-
-      sources.foldLeft(0){ case(idx,src) =>
-        src ~> merge.in(idx)
-        idx + 1
+      }.grouped(1000).foreach { dbos =>
+        val batch = dbos.toList.map(new InsertOneModel(_)).asJava
+        journalCollection.bulkWrite(batch, new BulkWriteOptions().ordered(false).bypassDocumentValidation(true))
+        ()
       }
 
-      merge.out ~> s
+      mongoClient.getDatabase(embedDB).getCollection("akka_persistence_journal").count() shouldBe EVENT_COUNT
 
-      ClosedShape
-    }
-    RunnableGraph.fromGraph(merged).run()
+      val readJournal =
+        PersistenceQuery(as).readJournalFor[ScalaDslMongoReadJournal](MongoReadJournal.Identifier)
 
-    ars foreach { ar =>
-      events foreach ( ar ! _)
-    }
+      val fut = readJournal.currentPersistenceIds().runFold(0) { case (inc, _) => inc + 1 }
+      Await.result(fut, 10.seconds.dilated) shouldBe EVENT_COUNT
 
-    implicit val ec = as.dispatcher
+      eventually {
+        mongoClient.getDatabase(embedDB).listCollectionNames()
+          .into(new java.util.HashSet[String]()).asScala.filter(_.startsWith("persistenceids-")) should have size 0L
+      }(PatienceConfig(timeout = Span(5L, Seconds), interval = Span(500L, Millis)))
+  }
 
-    val done = Future.sequence(promises.toSeq.map(_._1.future))
-    Await.result(done, 45.seconds.dilated)
+  it should "support the all persistence ids query" in withConfig(config(extensionClass), "akka-contrib-mongodb-persistence-readjournal") {
+    case (as, _) =>
+      import concurrent.duration._
+      implicit val system = as
+      implicit val mat = ActorMaterializer()
 
+      val promises = ("1" :: "2" :: "3" :: "4" :: "5" :: Nil).map(id => id -> Promise[Unit]())
+      val ars = promises.map { case (id, p) => as.actorOf(props(id, p)) }
+      val events = ("this" :: "is" :: "a" :: "test" :: Nil) map Append.apply
 
-    probe.receiveN(nrOfActors * nrOfEvents, 1.seconds.dilated)
-    ()
+      implicit val ec = as.dispatcher
+
+      val readJournal =
+        PersistenceQuery(as).readJournalFor[ScalaDslMongoReadJournal](MongoReadJournal.Identifier)
+
+      val probe = TestProbe()
+
+      ars slice (0, 3) foreach { ar =>
+        events foreach (ar ! _)
+      }
+
+      readJournal.allPersistenceIds().runForeach { pid =>
+        probe.ref ! pid
+      }
+
+      ars slice (3, 5) foreach { ar =>
+        events foreach (ar ! _)
+      }
+
+      probe.receiveN(ars.size, 10.seconds.dilated).collect { case x: String => x } should contain allOf ("1", "2", "3", "4", "5")
+  }
+
+  it should "support the current events by id query" in withConfig(config(extensionClass), "akka-contrib-mongodb-persistence-readjournal") {
+    case (as, _) =>
+      import concurrent.duration._
+      implicit val system = as
+      implicit val mat = ActorMaterializer()
+
+      val events = ("this" :: "is" :: "just" :: "a" :: "test" :: "END" :: Nil) map Append.apply
+
+      val promise = Promise[Unit]()
+      val ar = as.actorOf(props("foo", promise))
+
+      events foreach (ar ! _)
+
+      Await.result(promise.future, 10.seconds.dilated)
+
+      val readJournal =
+        PersistenceQuery(as).readJournalFor[ScalaDslMongoReadJournal](MongoReadJournal.Identifier)
+
+      val fut = readJournal.currentEventsByPersistenceId("foo", 0L, 2L).runFold(events.toSet) { (received, ee) =>
+        val asAppend = Append(ee.event.asInstanceOf[String])
+        events should contain(asAppend)
+        received - asAppend
+      }
+
+      Await.result(fut, 10.seconds.dilated).map(_.s) shouldBe Set("just", "a", "test", "END")
+  }
+
+  it should "support the events by id query" in withConfig(config(extensionClass), "akka-contrib-mongodb-persistence-readjournal") {
+    case (as, _) =>
+      import concurrent.duration._
+      implicit val system = as
+      implicit val mat = ActorMaterializer()
+
+      val readJournal =
+        PersistenceQuery(as).readJournalFor[ScalaDslMongoReadJournal](MongoReadJournal.Identifier)
+
+      val promise = Promise[Unit]()
+      val ar = as.actorOf(props("foo-live", promise))
+
+      val events = ("foo" :: "bar" :: "bar2" :: Nil) map Append.apply
+
+      val probe = TestProbe()
+
+      readJournal.eventsByPersistenceId("foo-live", 2L, 3L).runForeach(probe.ref ! _)
+
+      events foreach (ar ! _)
+
+      probe.receiveN(2, 10.seconds.dilated).collect { case msg: EventEnvelope => msg }.toList.map(_.event) should contain allOf ("bar", "bar2")
+  }
+
+  it should "support the events by id query with multiple persistent actors" in withConfig(config(extensionClass), "akka-contrib-mongodb-persistence-readjournal") {
+    case (as, _) =>
+      import concurrent.duration._
+      implicit val system = as
+      implicit val mat = ActorMaterializer()
+
+      val readJournal =
+        PersistenceQuery(as).readJournalFor[ScalaDslMongoReadJournal](MongoReadJournal.Identifier)
+
+      val promise = Promise[Unit]()
+      val promise2 = Promise[Unit]()
+      val ar = as.actorOf(props("foo-live-2a", promise))
+      val ar2 = as.actorOf(props("foo-live-2b", promise2))
+
+      val events = ("foo" :: "bar" :: "bar2" :: Nil) map Append.apply
+      val events2 = ("just" :: "a" :: "test" :: Nil) map Append.apply
+
+      val probe = TestProbe()
+
+      readJournal.eventsByPersistenceId("foo-live-2b", 0L, Long.MaxValue).take(events2.size.toLong).runForeach(probe.ref ! _)
+
+      events foreach (ar ! _)
+      events2 foreach (ar2 ! _)
+
+      probe.receiveN(events2.size, 10.seconds.dilated).collect { case msg: EventEnvelope => msg }.toList.map(_.event) should be(events2.map(_.s))
+  }
+
+  it should "support read 1k events from journal" in withConfig(config(extensionClass), "akka-contrib-mongodb-persistence-readjournal") {
+    case (as, _) =>
+      import concurrent.duration._
+      implicit val system = as
+      implicit val mat = ActorMaterializer()
+
+      val readJournal =
+        PersistenceQuery(as).readJournalFor[ScalaDslMongoReadJournal](MongoReadJournal.Identifier)
+
+      val nrOfActors = 10
+      val nrOfEvents = 100
+      val promises = (1 to nrOfActors).map(_ => Promise[Unit]()).zipWithIndex
+      val ars = promises map { case (p, idx) => system.actorOf(props(s"pid-${idx + 1}", p), s"actor-${idx + 1}") }
+      val events = (1 to nrOfEvents).map(eventId => Append.apply(s"eventd-$eventId")) :+ Append("END")
+
+      val probe = TestProbe()
+
+      val sources = (1 to nrOfActors) map (nr => readJournal.eventsByPersistenceId(s"pid-$nr", 0, Long.MaxValue).take(events.size.toLong))
+
+      val sink = Sink.actorRef(probe.ref, "complete")
+
+      val merged = GraphDSL.create(sink) { implicit b =>
+        (s) =>
+          import GraphDSL.Implicits._
+
+          val merge = b.add(Merge[EventEnvelope](sources.size))
+
+          sources.foldLeft(0) {
+            case (idx, src) =>
+              src ~> merge.in(idx)
+              idx + 1
+          }
+
+          merge.out ~> s
+
+          ClosedShape
+      }
+      RunnableGraph.fromGraph(merged).run()
+
+      ars foreach { ar =>
+        events foreach (ar ! _)
+      }
+
+      implicit val ec = as.dispatcher
+
+      val done = Future.sequence(promises.toSeq.map(_._1.future))
+      Await.result(done, 45.seconds.dilated)
+
+      probe.receiveN(nrOfActors * nrOfEvents, 1.seconds.dilated)
+      ()
   }
 }

--- a/common/src/test/scala/akka/contrib/persistence/mongodb/ReadJournalSpec.scala
+++ b/common/src/test/scala/akka/contrib/persistence/mongodb/ReadJournalSpec.scala
@@ -138,7 +138,7 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
       }
       events slice (3, 6) foreach (ar2 ! _)
 
-      Await.result(promise.future, 3.seconds.dilated) shouldBe 4
+      Await.result(promise.future, 10.seconds.dilated) shouldBe 4
 
       probe.receiveN(events.size, 10.seconds.dilated).collect { case msg: EventEnvelope => msg.event.toString } should contain allOf ("this", "is", "just", "a", "test", "END")
   }
@@ -368,7 +368,7 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
       implicit val ec = as.dispatcher
 
       val done = Future.sequence(promises.toSeq.map(_._1.future))
-      Await.result(done, 45.seconds.dilated)
+      Await.result(done, 1.minute.dilated)
 
       probe.receiveN(nrOfActors * nrOfEvents, 1.seconds.dilated)
       ()

--- a/common/src/test/scala/akka/contrib/persistence/mongodb/SnapshotTckSpec.scala
+++ b/common/src/test/scala/akka/contrib/persistence/mongodb/SnapshotTckSpec.scala
@@ -1,3 +1,9 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 import akka.persistence.snapshot.SnapshotStoreSpec
@@ -6,7 +12,7 @@ import org.scalatest.BeforeAndAfterAll
 
 object SnapshotTckSpec extends ContainerMongo {
 
-  def config(extensionClass: Class[_], database: String) = ConfigFactory.parseString(s"""
+  def config(extensionClass: Class[_], database: String, extendedConfig: String = "|") = ConfigFactory.parseString(s"""
     |akka.persistence.snapshot-store.plugin = "akka-contrib-mongodb-persistence-snapshot"
     |akka.persistence.journal.leveldb.native = off
     |akka.contrib.persistence.mongodb.mongo.driver = "${extensionClass.getName}"
@@ -16,11 +22,12 @@ object SnapshotTckSpec extends ContainerMongo {
     |	  # Class name of the plugin.
     |  class = "akka.contrib.persistence.mongodb.MongoSnapshots"
     |}
+    $extendedConfig
     """.stripMargin)
 }
 
-abstract class SnapshotTckSpec(extensionClass: Class[_], dbName: String)
-  extends SnapshotStoreSpec(SnapshotTckSpec.config(extensionClass,dbName)) with BeforeAndAfterAll {
+abstract class SnapshotTckSpec(extensionClass: Class[_], dbName: String, extendedConfig: String = "|")
+  extends SnapshotStoreSpec(SnapshotTckSpec.config(extensionClass,dbName,extendedConfig)) with BeforeAndAfterAll {
 
   override def afterAll() = {
     SnapshotTckSpec.cleanup(dbName)

--- a/common/src/test/scala/akka/contrib/persistence/mongodb/SuffixCollectionNamesTest.scala
+++ b/common/src/test/scala/akka/contrib/persistence/mongodb/SuffixCollectionNamesTest.scala
@@ -19,8 +19,8 @@ object SuffixCollectionNamesTest {
   val rxMongoExtendedConfig = """
     |akka.contrib.persistence.mongodb.mongo.use-suffixed-collection-names = true 
     |akka.contrib.persistence.mongodb.mongo.suffix-builder.class = "akka.contrib.persistence.mongodb.SuffixCollectionNamesTest"
-    |akka.contrib.persistence.mongodb.rxmongo.failover.initialDelay = 300ms 
-    |akka.contrib.persistence.mongodb.rxmongo.failover.retries = 15
+    |akka.contrib.persistence.mongodb.rxmongo.failover.initialDelay = 750ms 
+    |akka.contrib.persistence.mongodb.rxmongo.failover.retries = 10
     |akka.contrib.persistence.mongodb.rxmongo.failover.growth = con
     |akka.contrib.persistence.mongodb.rxmongo.failover.factor = 1
     |""".stripMargin

--- a/common/src/test/scala/akka/contrib/persistence/mongodb/SuffixCollectionNamesTest.scala
+++ b/common/src/test/scala/akka/contrib/persistence/mongodb/SuffixCollectionNamesTest.scala
@@ -15,4 +15,14 @@ object SuffixCollectionNamesTest {
     |akka.contrib.persistence.mongodb.mongo.use-suffixed-collection-names = true 
     |akka.contrib.persistence.mongodb.mongo.suffix-builder.class = "akka.contrib.persistence.mongodb.SuffixCollectionNamesTest"
     |""".stripMargin
+    
+  val rxMongoExtendedConfig = """
+    |akka.contrib.persistence.mongodb.mongo.use-suffixed-collection-names = true 
+    |akka.contrib.persistence.mongodb.mongo.suffix-builder.class = "akka.contrib.persistence.mongodb.SuffixCollectionNamesTest"
+    |akka.contrib.persistence.mongodb.rxmongo.failover.initialDelay = 300ms 
+    |akka.contrib.persistence.mongodb.rxmongo.failover.retries = 15
+    |akka.contrib.persistence.mongodb.rxmongo.failover.growth = con
+    |akka.contrib.persistence.mongodb.rxmongo.failover.factor = 1
+    |akka.test.default-timeout = 5 seconds
+    |""".stripMargin
 }

--- a/common/src/test/scala/akka/contrib/persistence/mongodb/SuffixCollectionNamesTest.scala
+++ b/common/src/test/scala/akka/contrib/persistence/mongodb/SuffixCollectionNamesTest.scala
@@ -12,12 +12,10 @@ class SuffixCollectionNamesTest extends CanSuffixCollectionNames {
 
 object SuffixCollectionNamesTest {
   val extendedConfig = """
-    |akka.contrib.persistence.mongodb.mongo.use-suffixed-collection-names = true 
     |akka.contrib.persistence.mongodb.mongo.suffix-builder.class = "akka.contrib.persistence.mongodb.SuffixCollectionNamesTest"
     |""".stripMargin
     
   val rxMongoExtendedConfig = """
-    |akka.contrib.persistence.mongodb.mongo.use-suffixed-collection-names = true 
     |akka.contrib.persistence.mongodb.mongo.suffix-builder.class = "akka.contrib.persistence.mongodb.SuffixCollectionNamesTest"
     |akka.contrib.persistence.mongodb.rxmongo.failover.initialDelay = 750ms 
     |akka.contrib.persistence.mongodb.rxmongo.failover.retries = 10

--- a/common/src/test/scala/akka/contrib/persistence/mongodb/SuffixCollectionNamesTest.scala
+++ b/common/src/test/scala/akka/contrib/persistence/mongodb/SuffixCollectionNamesTest.scala
@@ -7,7 +7,7 @@
 package akka.contrib.persistence.mongodb
 
 class SuffixCollectionNamesTest extends CanSuffixCollectionNames {
-  override def getSuffixFromPersistenceId(persistenceId: String): String = persistenceId  
+  override def getSuffixFromPersistenceId(persistenceId: String): String = s"$persistenceId-test"  
 }
 
 object SuffixCollectionNamesTest {

--- a/common/src/test/scala/akka/contrib/persistence/mongodb/SuffixCollectionNamesTest.scala
+++ b/common/src/test/scala/akka/contrib/persistence/mongodb/SuffixCollectionNamesTest.scala
@@ -23,6 +23,5 @@ object SuffixCollectionNamesTest {
     |akka.contrib.persistence.mongodb.rxmongo.failover.retries = 15
     |akka.contrib.persistence.mongodb.rxmongo.failover.growth = con
     |akka.contrib.persistence.mongodb.rxmongo.failover.factor = 1
-    |akka.test.default-timeout = 5 seconds
     |""".stripMargin
 }

--- a/common/src/test/scala/akka/contrib/persistence/mongodb/SuffixCollectionNamesTest.scala
+++ b/common/src/test/scala/akka/contrib/persistence/mongodb/SuffixCollectionNamesTest.scala
@@ -1,0 +1,18 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
+package akka.contrib.persistence.mongodb
+
+class SuffixCollectionNamesTest extends CanSuffixCollectionNames {
+  override def getSuffixFromPersistenceId(persistenceId: String): String = persistenceId  
+}
+
+object SuffixCollectionNamesTest {
+  val extendedConfig = """
+    |akka.contrib.persistence.mongodb.mongo.use-suffixed-collection-names = true 
+    |akka.contrib.persistence.mongodb.mongo.suffix-builder.class = "akka.contrib.persistence.mongodb.SuffixCollectionNamesTest"
+    |""".stripMargin
+}

--- a/docs/akka24.md
+++ b/docs/akka24.md
@@ -405,7 +405,7 @@ Some more information is covered in [#43](https://github.com/scullxbones/akka-pe
 #### Overview
 Without any further configuration, events are stored in some unique collection, named by default "akka_persistence_journal", while snapshots are stored in "akka_persistence_snaps". This is the primary and widely used behavior of event sourcing through Akka-persistence, but it may happen to be insufficient in some cases.
 
-As described [in issue #39](https://github.com/scullxbones/akka-persistence-mongo/issues/39), some kind of `persistenceId` mapping to collection names should do the trick, and this is what inspired the *suffixed collection names* feature development.
+As described in issue [#39](https://github.com/scullxbones/akka-persistence-mongo/issues/39), some kind of `persistenceId` mapping to collection names should do the trick, and this is what inspired the *suffixed collection names* feature development.
 
 The main idea here is to create as many journal and snapshot collections as needed, which names are built from default (or [configured](#mongocollection)) names, *suffixed* by a separator, followed by some information "picked" from `persistenceId`.
 
@@ -424,7 +424,7 @@ journal name would be "akka_persistence_journal_*suffix*" while snapshot name wo
 
 ##### Important notes:
 * capped collections keep their name, respectively "akka_persistence_realtime" and "akka_persistence_metadata" by default. They remain out of *suffixed collection names* feature scope.
-* the *suffixed collection names* feature does **not** have *yet* any migration process, so it should **not** be used on existing database.
+* the *suffixed collection names* feature does **not** have *yet* any migration process, so it should **not** be used with existing database.
 
 <a name="suffixusage"/>
 #### Usage
@@ -438,7 +438,7 @@ akka.contrib.persistence.mongodb.mongo.suffix-builder.separator = "_"
 akka.contrib.persistence.mongodb.mongo.suffix-builder.class = "com.mycompany.myproject.SuffixCollectionNames"
 ```
 
-First line purpose is obvious: enabling or not he feature. If set to *false*, both the remaining lines are ignored. By default, this property is set to false.
+First line purpose is obvious: enabling or not the feature. If set to *false*, both the remaining lines are ignored. By default, this property is set to false.
 
 If set to *true*, nothing happens as long as you do not provide a class extending or mixing in `akka.contrib.persistence.mongodb.CanSuffixCollectionNames` trait, nor if its `getSuffixfromPersistenceId` method returns an empty string.
 

--- a/docs/akka24.md
+++ b/docs/akka24.md
@@ -433,18 +433,15 @@ Using the *suffixed collection names* feature is a matter of configuration and a
 ##### Configuration
 Inside your `application.conf` file, use the following lines to enable the feature:
 ```
-akka.contrib.persistence.mongodb.mongo.use-suffixed-collection-names = true
 akka.contrib.persistence.mongodb.mongo.suffix-builder.separator = "_"
 akka.contrib.persistence.mongodb.mongo.suffix-builder.class = "com.mycompany.myproject.SuffixCollectionNames"
 ```
 
-First line purpose is obvious: enabling or not the feature. If set to *false*, both the remaining lines are ignored. By default, this property is set to false.
+Nothing happens as long as you do not provide a class extending or mixing in `akka.contrib.persistence.mongodb.CanSuffixCollectionNames` trait, nor if its `getSuffixfromPersistenceId` method returns an empty string.
 
-If set to *true*, nothing happens as long as you do not provide a class extending or mixing in `akka.contrib.persistence.mongodb.CanSuffixCollectionNames` trait, nor if its `getSuffixfromPersistenceId` method returns an empty string.
+First line defines a separator as a `String`, but only its first character will be used as a separator (keep in mind that mongoDB does not allow collection names longer than 64 characters) By default, this property is set to an underscore character "_".
 
-Second line defines a separator as a `String`, but only its first character will be used as a separator (keep in mind that mongoDB does not allow collection names longer than 64 characters) By default, this property is set to an underscore character "_".
-
-Third line contains the entire package+name of the user class extending or mixing in `akka.contrib.persistence.mongodb.CanSuffixCollectionNames` trait (see below). By default, this property is set to an internal `akka.contrib.persistence.mongodb.SuffixCollectionNames` class, which `getSuffixfromPersistenceId` function returns an empty string, leading to **not** suffix any collection..
+Second line contains the entire package+name of the user class extending or mixing in `akka.contrib.persistence.mongodb.CanSuffixCollectionNames` trait (see below).
 
 ##### Code
 Add some `com.mycompany.myproject.SuffixCollectionNames` class in your code, extending or mixing in `akka.contrib.persistence.mongodb.CanSuffixCollectionNames` trait:
@@ -465,7 +462,7 @@ class SuffixCollectionNames extends CanSuffixCollectionNames {
 }
 ```
 
-Remember that returning an empty `String` will *not* suffix any collection name, even if some separator is defined in the configuration file. This behavior is the default one, as implemented in the default internal `akka.contrib.persistence.mongodb.SuffixCollectionNames` class.
+Remember that returning an empty `String` will *not* suffix any collection name, even if some separator is defined in the configuration file.
 
 <a name="suffixdetail"/>
 #### Details

--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoJournaller.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoJournaller.scala
@@ -108,7 +108,7 @@ class RxMongoJournaller(driver: RxMongoDriver) extends MongoPersistenceJournalli
       val fZero = Future[ISeq[Try[Unit]]] { ISeq.empty[Try[Unit]] }
 
       // this should guarantee that futures are performed sequentially...
-      writes.groupBy(w => driver.getSuffixFromPersistenceId(w.persistenceId)).toList // list of tuples (persistenceId: String, writeSeq: Seq[AtomicWrite])
+      writes.groupBy(_.persistenceId).toList // list of tuples (persistenceId: String, writeSeq: Seq[AtomicWrite])
         .foldLeft(fZero) { (future, tuple) => future.flatMap { _ => doBatchJournalAppend(tuple._2, driver.journal(tuple._1)) } }
 
     } else {

--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoJournaller.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoJournaller.scala
@@ -108,7 +108,7 @@ class RxMongoJournaller(driver: RxMongoDriver) extends MongoPersistenceJournalli
       val fZero = Future[ISeq[Try[Unit]]] { ISeq.empty[Try[Unit]] }
 
       // this should guarantee that futures are performed sequentially...
-      writes.groupBy(_.persistenceId).toList // list of tuples (persistenceId: String, writeSeq: Seq[AtomicWrite])
+      writes.groupBy(w => driver.getSuffixFromPersistenceId(w.persistenceId)).toList // list of tuples (persistenceId: String, writeSeq: Seq[AtomicWrite])
         .foldLeft(fZero) { (future, tuple) => future.flatMap { _ => doBatchJournalAppend(tuple._2, driver.journal(tuple._1)) } }
 
     } else {

--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoSnapshotter.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoSnapshotter.scala
@@ -1,3 +1,9 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 import akka.persistence.SelectedSnapshot
@@ -17,7 +23,7 @@ class RxMongoSnapshotter(driver: RxMongoDriver) extends MongoPersistenceSnapshot
 
   private[mongodb] def findYoungestSnapshotByMaxSequence(pid: String, maxSeq: Long, maxTs: Long)(implicit ec: ExecutionContext) = {
     val selected =
-      snaps.find(
+      snaps(pid).find(
         BSONDocument(PROCESSOR_ID -> pid,
           SEQUENCE_NUMBER -> BSONDocument("$lte" -> maxSeq),
           TIMESTAMP -> BSONDocument("$lte" -> maxTs)
@@ -33,31 +39,31 @@ class RxMongoSnapshotter(driver: RxMongoDriver) extends MongoPersistenceSnapshot
       SEQUENCE_NUMBER -> snapshot.metadata.sequenceNr,
       TIMESTAMP -> snapshot.metadata.timestamp
     )
-    snaps.update(query, snapshot, writeConcern, upsert = true, multi = false).map(_ => ())
+    snaps(snapshot.metadata.persistenceId).update(query, snapshot, writeConcern, upsert = true, multi = false).map(_ => ())
   }
 
   private[mongodb] def deleteSnapshot(pid: String, seq: Long, ts: Long)(implicit ec: ExecutionContext) = {
     val criteria =
       Seq[Producer[BSONElement]](PROCESSOR_ID -> pid, SEQUENCE_NUMBER -> seq) ++
         Option[Producer[BSONElement]](TIMESTAMP -> ts).filter(_ => ts > 0).toSeq
-    snaps.remove(BSONDocument(criteria : _*), writeConcern).map(_ => ())
+    snaps(pid).remove(BSONDocument(criteria : _*), writeConcern).map(_ => ())
   }
 
   private[mongodb] def deleteMatchingSnapshots(pid: String, maxSeq: Long, maxTs: Long)(implicit ec: ExecutionContext) =
-    snaps.remove(BSONDocument(PROCESSOR_ID -> pid,
+    snaps(pid).remove(BSONDocument(PROCESSOR_ID -> pid,
                               SEQUENCE_NUMBER -> BSONDocument("$lte" -> maxSeq),
                               TIMESTAMP -> BSONDocument("$lte" -> maxTs)),
                               writeConcern).map(_ => ())
 
-  private[this] def snaps(implicit ec: ExecutionContext) = {
-    val snaps = driver.collection(driver.snapsCollectionName)
+  private[this] def snaps(suffix: String)(implicit ec: ExecutionContext) = {
+    val snaps = driver.getSnaps(suffix)
     snaps.indexesManager.ensure(new Index(
       key = Seq((PROCESSOR_ID, IndexType.Ascending),
         (SEQUENCE_NUMBER, IndexType.Descending),
         (TIMESTAMP, IndexType.Descending)),
       background = true,
       unique = true,
-      name = Some(driver.snapsIndexName)))
+      name = Some(driver.getSnapsIndexName(suffix))))
     snaps
   }
 

--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoSnapshotter.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoSnapshotter.scala
@@ -63,7 +63,7 @@ class RxMongoSnapshotter(driver: RxMongoDriver) extends MongoPersistenceSnapshot
         (TIMESTAMP, IndexType.Descending)),
       background = true,
       unique = true,
-      name = Some(driver.getSnapsIndexName(suffix))))
+      name = Some(driver.snapsIndexName)))
     snaps
   }
 

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoConfigTest.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoConfigTest.scala
@@ -6,7 +6,6 @@ object RxMongoConfigTest {
     |akka.contrib.persistence.mongodb.rxmongo.failover.retries = 15
     |akka.contrib.persistence.mongodb.rxmongo.failover.growth = con
     |akka.contrib.persistence.mongodb.rxmongo.failover.factor = 1
-    |akka.test.default-timeout = 5 seconds
     |""".stripMargin
   
 }

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoConfigTest.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoConfigTest.scala
@@ -1,0 +1,12 @@
+package akka.contrib.persistence.mongodb
+
+object RxMongoConfigTest {
+  val rxMongoConfig = """
+    |akka.contrib.persistence.mongodb.rxmongo.failover.initialDelay = 300ms 
+    |akka.contrib.persistence.mongodb.rxmongo.failover.retries = 15
+    |akka.contrib.persistence.mongodb.rxmongo.failover.growth = con
+    |akka.contrib.persistence.mongodb.rxmongo.failover.factor = 1
+    |akka.test.default-timeout = 5 seconds
+    |""".stripMargin
+  
+}

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoConfigTest.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoConfigTest.scala
@@ -2,8 +2,8 @@ package akka.contrib.persistence.mongodb
 
 object RxMongoConfigTest {
   val rxMongoConfig = """
-    |akka.contrib.persistence.mongodb.rxmongo.failover.initialDelay = 300ms 
-    |akka.contrib.persistence.mongodb.rxmongo.failover.retries = 15
+    |akka.contrib.persistence.mongodb.rxmongo.failover.initialDelay = 750ms 
+    |akka.contrib.persistence.mongodb.rxmongo.failover.retries = 10
     |akka.contrib.persistence.mongodb.rxmongo.failover.growth = con
     |akka.contrib.persistence.mongodb.rxmongo.failover.factor = 1
     |""".stripMargin

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoJournal1kSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoJournal1kSpec.scala
@@ -6,6 +6,6 @@
 
 package akka.contrib.persistence.mongodb
 
-class RxMongoJournal1kSpec extends Journal1kSpec(classOf[RxMongoPersistenceExtension],"rxmongo")
+class RxMongoJournal1kSpec extends Journal1kSpec(classOf[RxMongoPersistenceExtension],"rxmongo", RxMongoConfigTest.rxMongoConfig)
 
-class RxMongoSuffixJournal1kSpec extends Journal1kSpec(classOf[RxMongoPersistenceExtension], "rxmongo", SuffixCollectionNamesTest.extendedConfig)
+class RxMongoSuffixJournal1kSpec extends Journal1kSpec(classOf[RxMongoPersistenceExtension], "rxmongo", SuffixCollectionNamesTest.rxMongoExtendedConfig)

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoJournal1kSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoJournal1kSpec.scala
@@ -1,3 +1,11 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 class RxMongoJournal1kSpec extends Journal1kSpec(classOf[RxMongoPersistenceExtension],"rxmongo")
+
+class RxMongoSuffixJournal1kSpec extends Journal1kSpec(classOf[RxMongoPersistenceExtension], "rxmongo", SuffixCollectionNamesTest.extendedConfig)

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoJournalLoadSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoJournalLoadSpec.scala
@@ -6,6 +6,6 @@
 
 package akka.contrib.persistence.mongodb
 
-class RxMongoJournalLoadSpec extends JournalLoadSpec(classOf[RxMongoPersistenceExtension],"rxmongo")
+class RxMongoJournalLoadSpec extends JournalLoadSpec(classOf[RxMongoPersistenceExtension],"rxmongo", RxMongoConfigTest.rxMongoConfig)
 
-class RxMongoSuffixJournalLoadSpec extends JournalLoadSpec(classOf[RxMongoPersistenceExtension], "rxmongo", SuffixCollectionNamesTest.extendedConfig)
+class RxMongoSuffixJournalLoadSpec extends JournalLoadSpec(classOf[RxMongoPersistenceExtension], "rxmongo", SuffixCollectionNamesTest.rxMongoExtendedConfig)

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoJournalLoadSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoJournalLoadSpec.scala
@@ -1,3 +1,11 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 class RxMongoJournalLoadSpec extends JournalLoadSpec(classOf[RxMongoPersistenceExtension],"rxmongo")
+
+class RxMongoSuffixJournalLoadSpec extends JournalLoadSpec(classOf[RxMongoPersistenceExtension], "rxmongo", SuffixCollectionNamesTest.extendedConfig)

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoJournalSerializableSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoJournalSerializableSpec.scala
@@ -1,3 +1,11 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 class RxMongoJournalSerializableSpec extends JournalSerializableSpec(classOf[RxMongoPersistenceExtension],"rxmongo")
+
+class RxMongoSuffixJournalSerializableSpec extends JournalSerializableSpec(classOf[RxMongoPersistenceExtension],"rxmongo", SuffixCollectionNamesTest.extendedConfig)

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoJournalSerializableSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoJournalSerializableSpec.scala
@@ -6,6 +6,6 @@
 
 package akka.contrib.persistence.mongodb
 
-class RxMongoJournalSerializableSpec extends JournalSerializableSpec(classOf[RxMongoPersistenceExtension],"rxmongo")
+class RxMongoJournalSerializableSpec extends JournalSerializableSpec(classOf[RxMongoPersistenceExtension],"rxmongo", RxMongoConfigTest.rxMongoConfig)
 
-class RxMongoSuffixJournalSerializableSpec extends JournalSerializableSpec(classOf[RxMongoPersistenceExtension],"rxmongo", SuffixCollectionNamesTest.extendedConfig)
+class RxMongoSuffixJournalSerializableSpec extends JournalSerializableSpec(classOf[RxMongoPersistenceExtension],"rxmongo", SuffixCollectionNamesTest.rxMongoExtendedConfig)

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoJournalUpgradeSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoJournalUpgradeSpec.scala
@@ -6,6 +6,6 @@
 
 package akka.contrib.persistence.mongodb
 
-class RxMongoJournalUpgradeSpec extends JournalUpgradeSpec(classOf[RxMongoPersistenceExtension], "rxmongo", new RxMongoDriver(_,_))
+class RxMongoJournalUpgradeSpec extends JournalUpgradeSpec(classOf[RxMongoPersistenceExtension], "rxmongo", new RxMongoDriver(_,_), RxMongoConfigTest.rxMongoConfig)
 
-class RxMongoSuffixJournalUpgradeSpec extends JournalUpgradeSpec(classOf[RxMongoPersistenceExtension], "rxmongo", new RxMongoDriver(_,_), SuffixCollectionNamesTest.extendedConfig)
+class RxMongoSuffixJournalUpgradeSpec extends JournalUpgradeSpec(classOf[RxMongoPersistenceExtension], "rxmongo", new RxMongoDriver(_,_), SuffixCollectionNamesTest.rxMongoExtendedConfig)

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoJournalUpgradeSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoJournalUpgradeSpec.scala
@@ -1,3 +1,11 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 class RxMongoJournalUpgradeSpec extends JournalUpgradeSpec(classOf[RxMongoPersistenceExtension], "rxmongo", new RxMongoDriver(_,_))
+
+class RxMongoSuffixJournalUpgradeSpec extends JournalUpgradeSpec(classOf[RxMongoPersistenceExtension], "rxmongo", new RxMongoDriver(_,_), SuffixCollectionNamesTest.extendedConfig)

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoJournalUpgradeSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoJournalUpgradeSpec.scala
@@ -7,5 +7,3 @@
 package akka.contrib.persistence.mongodb
 
 class RxMongoJournalUpgradeSpec extends JournalUpgradeSpec(classOf[RxMongoPersistenceExtension], "rxmongo", new RxMongoDriver(_,_), RxMongoConfigTest.rxMongoConfig)
-
-class RxMongoSuffixJournalUpgradeSpec extends JournalUpgradeSpec(classOf[RxMongoPersistenceExtension], "rxmongo", new RxMongoDriver(_,_), SuffixCollectionNamesTest.rxMongoExtendedConfig)

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoJournallerSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoJournallerSpec.scala
@@ -1,11 +1,17 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 import akka.actor.ActorSystem
-import akka.persistence.{AtomicWrite, PersistentRepr}
+import akka.persistence.{ AtomicWrite, PersistentRepr }
 import akka.serialization.SerializationExtension
 import akka.testkit._
 import reactivemongo.bson._
-import scala.collection.immutable.{Seq => ISeq}
+import scala.collection.immutable.{ Seq => ISeq }
 import scala.concurrent._
 import scala.concurrent.duration._
 import play.api.libs.iteratee.Iteratee
@@ -19,59 +25,132 @@ class RxMongoJournallerSpec extends TestKit(ActorSystem("unit-test")) with RxMon
   implicit val as = system
 
   def await[T](block: Future[T])(implicit ec: ExecutionContext) = {
-    Await.result(block,3.seconds.dilated)
+    Await.result(block, 3.seconds.dilated)
   }
 
   trait Fixture {
     val underTest = new RxMongoJournaller(driver)
-    val records:List[PersistentRepr] = List(1L, 2L, 3L).map { sq =>
+
+    val underExtendedTest = new RxMongoJournaller(extendedDriver)
+
+    val records: List[PersistentRepr] = List(1L, 2L, 3L).map { sq =>
       PersistentRepr(payload = "payload", sequenceNr = sq, persistenceId = "unit-test")
     }
-    val documents:List[PersistentRepr]  = List(10L, 20L, 30L).map { sq =>
+    val documents: List[PersistentRepr] = List(10L, 20L, 30L).map { sq =>
       PersistentRepr(payload = BSONDocument("foo" -> "bar", "baz" -> 1), sequenceNr = sq, persistenceId = "unit-test")
     }
   }
 
-  "A reactive mongo journal implementation" should "insert journal records" in { new Fixture { withJournal { journal =>
-    val inserted = for {
-      inserted <- underTest.batchAppend(ISeq(AtomicWrite(records)))
-      range <- journal.find(BSONDocument()).cursor[BSONDocument]().collect[List]()
-      head <- journal.find(BSONDocument()).cursor().headOption
-    } yield (range, head)
-    val (range, head) = await(inserted)
-    range should have size 1
-    
-    underTest.journalRange("unit-test",1,3,Int.MaxValue).run(Iteratee.getChunks[Event]) onFailure {
-      case t => t.printStackTrace()
+  "A reactive mongo journal implementation" should "insert journal records" in {
+    new Fixture {
+      withJournal { journal =>
+        val inserted = for {
+          inserted <- underTest.batchAppend(ISeq(AtomicWrite(records)))
+          range <- journal.find(BSONDocument()).cursor[BSONDocument]().collect[List]()
+          head <- journal.find(BSONDocument()).cursor().headOption
+        } yield (range, head)
+        val (range, head) = await(inserted)
+        range should have size 1
+
+        underTest.journalRange("unit-test", 1, 3, Int.MaxValue).run(Iteratee.getChunks[Event]) onFailure {
+          case t => t.printStackTrace()
+        }
+
+        val recone = head.get.getAs[BSONArray](EVENTS).toStream.flatMap(_.values.collect {
+          case e: BSONDocument => e
+        }).head
+        recone.getAs[String](PROCESSOR_ID) shouldBe Some("unit-test")
+        recone.getAs[Long](SEQUENCE_NUMBER) shouldBe Some(1)
+
+      }
     }
-    
-    val recone = head.get.getAs[BSONArray](EVENTS).toStream.flatMap(_.values.collect {
-      case e: BSONDocument => e
-    }).head
-    recone.getAs[String](PROCESSOR_ID) shouldBe Some("unit-test")
-    recone.getAs[Long](SEQUENCE_NUMBER) shouldBe Some(1)
-
-  } }
-  () }
-
-  it should "insert records with documents as payload" in { new Fixture { withJournal { journal =>
-    val inserted = for {
-      inserted <- underTest.batchAppend(ISeq(AtomicWrite(documents)))
-      range <- journal.find(BSONDocument()).cursor[BSONDocument]().collect[List]()
-      head <- journal.find(BSONDocument()).cursor().headOption
-    } yield (range,head)
-    val (range,head) = await(inserted)
-    range should have size 1
-
-    val recone = head.get.getAs[BSONArray](EVENTS).toStream.flatMap(_.values.collect {
-      case e: BSONDocument => e
-    }).head
-    recone.getAs[String](PROCESSOR_ID) shouldBe Some("unit-test")
-    recone.getAs[Long](SEQUENCE_NUMBER) shouldBe Some(10)
-    recone.getAs[String](TYPE) shouldBe Some("bson")
-    recone.getAs[BSONDocument](PayloadKey) shouldBe Some(BSONDocument("foo" -> "bar", "baz" -> 1))
     ()
-  } }
-  () }
+  }
+
+  it should "insert journal records in suffixed journal collection" in {
+    new Fixture {
+      withAutoSuffixedJournal { drv =>        
+        val journalName = drv.getJournalCollectionName("unit-test")
+
+        val inserted = for {
+          // should 'build' the journal suffixed by persistenceId: "unit-test"
+          inserted <- underExtendedTest.batchAppend(ISeq(AtomicWrite(records)))
+          
+          // should 'retrieve' (and not 'build') the suffixed journal
+          collections <- drv.db.collectionNames
+          journal = drv.collection(collections.filter(_.equals(journalName)).head)
+          
+          range <- journal.find(BSONDocument()).cursor[BSONDocument]().collect[List]()
+          head <- journal.find(BSONDocument()).cursor().headOption
+        } yield (range, head)
+        val (range, head) = await(inserted)
+        range should have size 1
+
+        underExtendedTest.journalRange("unit-test", 1, 3, Int.MaxValue).run(Iteratee.getChunks[Event]) onFailure {
+          case t => t.printStackTrace()
+        }
+
+        val recone = head.get.getAs[BSONArray](EVENTS).toStream.flatMap(_.values.collect {
+          case e: BSONDocument => e
+        }).head
+        recone.getAs[String](PROCESSOR_ID) shouldBe Some("unit-test")
+        recone.getAs[Long](SEQUENCE_NUMBER) shouldBe Some(1)
+
+      }
+    }
+    ()
+  }
+
+  it should "insert records with documents as payload" in {
+    new Fixture {
+      withJournal { journal =>
+        val inserted = for {
+          inserted <- underTest.batchAppend(ISeq(AtomicWrite(documents)))
+          range <- journal.find(BSONDocument()).cursor[BSONDocument]().collect[List]()
+          head <- journal.find(BSONDocument()).cursor().headOption
+        } yield (range, head)
+        val (range, head) = await(inserted)
+        range should have size 1
+
+        val recone = head.get.getAs[BSONArray](EVENTS).toStream.flatMap(_.values.collect {
+          case e: BSONDocument => e
+        }).head
+        recone.getAs[String](PROCESSOR_ID) shouldBe Some("unit-test")
+        recone.getAs[Long](SEQUENCE_NUMBER) shouldBe Some(10)
+        recone.getAs[String](TYPE) shouldBe Some("bson")
+        recone.getAs[BSONDocument](PayloadKey) shouldBe Some(BSONDocument("foo" -> "bar", "baz" -> 1))
+        ()
+      }
+    }
+    ()
+  }
+
+  it should "insert records with documents as payload in suffixed journal collection" in {
+    new Fixture {
+      withAutoSuffixedJournal { drv =>
+        val journalName = drv.getJournalCollectionName("unit-test")
+        
+        val inserted = for {
+          inserted <- underExtendedTest.batchAppend(ISeq(AtomicWrite(documents)))
+          collections <- drv.db.collectionNames
+          journal = drv.collection(collections.filter(_.equals(journalName)).head)
+          range <- journal.find(BSONDocument()).cursor[BSONDocument]().collect[List]()
+          head <- journal.find(BSONDocument()).cursor().headOption
+        } yield (range, head)
+        val (range, head) = await(inserted)
+        range should have size 1
+
+        val recone = head.get.getAs[BSONArray](EVENTS).toStream.flatMap(_.values.collect {
+          case e: BSONDocument => e
+        }).head
+        recone.getAs[String](PROCESSOR_ID) shouldBe Some("unit-test")
+        recone.getAs[Long](SEQUENCE_NUMBER) shouldBe Some(10)
+        recone.getAs[String](TYPE) shouldBe Some("bson")
+        recone.getAs[BSONDocument](PayloadKey) shouldBe Some(BSONDocument("foo" -> "bar", "baz" -> 1))
+        ()
+      }
+    }
+    ()
+  }
 
 }

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceJournalTckSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceJournalTckSpec.scala
@@ -1,3 +1,9 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 import org.junit.runner.RunWith
@@ -6,3 +12,6 @@ import org.scalatest.junit.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class RxMongoPersistenceJournalTckSpec extends JournalTckSpec(classOf[RxMongoPersistenceExtension], "rxMongoJournalTck")
 
+
+@RunWith(classOf[JUnitRunner])
+class RxMongoSuffixPersistenceJournalTckSpec extends JournalTckSpec(classOf[RxMongoPersistenceExtension], "rxMongoJournalTck", SuffixCollectionNamesTest.extendedConfig)

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceJournalTckSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceJournalTckSpec.scala
@@ -10,8 +10,8 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class RxMongoPersistenceJournalTckSpec extends JournalTckSpec(classOf[RxMongoPersistenceExtension], "rxMongoJournalTck")
+class RxMongoPersistenceJournalTckSpec extends JournalTckSpec(classOf[RxMongoPersistenceExtension], "rxMongoJournalTck", RxMongoConfigTest.rxMongoConfig)
 
 
 @RunWith(classOf[JUnitRunner])
-class RxMongoSuffixPersistenceJournalTckSpec extends JournalTckSpec(classOf[RxMongoPersistenceExtension], "rxMongoJournalTck", SuffixCollectionNamesTest.extendedConfig)
+class RxMongoSuffixPersistenceJournalTckSpec extends JournalTckSpec(classOf[RxMongoPersistenceExtension], "rxMongoJournalTck", SuffixCollectionNamesTest.rxMongoExtendedConfig)

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceSnapshotTckSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceSnapshotTckSpec.scala
@@ -1,3 +1,9 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 import org.junit.runner.RunWith
@@ -5,3 +11,6 @@ import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class RxMongoPersistenceSnapshotTckSpec extends SnapshotTckSpec(classOf[RxMongoPersistenceExtension], "rxmongo")
+
+@RunWith(classOf[JUnitRunner])
+class RxMongoSuffixPersistenceSnapshotTckSpec extends SnapshotTckSpec(classOf[RxMongoPersistenceExtension], "rxmongo", SuffixCollectionNamesTest.extendedConfig)

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceSnapshotTckSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceSnapshotTckSpec.scala
@@ -10,7 +10,7 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class RxMongoPersistenceSnapshotTckSpec extends SnapshotTckSpec(classOf[RxMongoPersistenceExtension], "rxmongo")
+class RxMongoPersistenceSnapshotTckSpec extends SnapshotTckSpec(classOf[RxMongoPersistenceExtension], "rxmongo", RxMongoConfigTest.rxMongoConfig)
 
 @RunWith(classOf[JUnitRunner])
-class RxMongoSuffixPersistenceSnapshotTckSpec extends SnapshotTckSpec(classOf[RxMongoPersistenceExtension], "rxmongo", SuffixCollectionNamesTest.extendedConfig)
+class RxMongoSuffixPersistenceSnapshotTckSpec extends SnapshotTckSpec(classOf[RxMongoPersistenceExtension], "rxmongo", SuffixCollectionNamesTest.rxMongoExtendedConfig)

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceSpec.scala
@@ -23,7 +23,6 @@ trait RxMongoPersistenceSpec extends MongoPersistenceSpec[RxMongoDriver, BSONCol
     .withValue("akka.contrib.persistence.mongodb.rxmongo.failover.retries", ConfigValueFactory.fromAnyRef(15))
     .withValue("akka.contrib.persistence.mongodb.rxmongo.failover.growth", ConfigValueFactory.fromAnyRef("con"))
     .withValue("akka.contrib.persistence.mongodb.rxmongo.failover.factor", ConfigValueFactory.fromAnyRef(1))
-    .withValue("akka.test.default-timeout", ConfigValueFactory.fromAnyRef("5 seconds"))
       ) {
     override def mongoUri = s"mongodb://$host:$noAuthPort/$embedDB"
 
@@ -35,7 +34,6 @@ trait RxMongoPersistenceSpec extends MongoPersistenceSpec[RxMongoDriver, BSONCol
     .withValue("akka.contrib.persistence.mongodb.rxmongo.failover.retries", ConfigValueFactory.fromAnyRef(15))
     .withValue("akka.contrib.persistence.mongodb.rxmongo.failover.growth", ConfigValueFactory.fromAnyRef("con"))
     .withValue("akka.contrib.persistence.mongodb.rxmongo.failover.factor", ConfigValueFactory.fromAnyRef(1))
-    .withValue("akka.test.default-timeout", ConfigValueFactory.fromAnyRef("5 seconds"))
     .withValue("akka.contrib.persistence.mongodb.mongo.use-suffixed-collection-names", ConfigValueFactory.fromAnyRef(true))
     .withValue("akka.contrib.persistence.mongodb.mongo.suffix-builder.class",
       ConfigValueFactory.fromAnyRef("akka.contrib.persistence.mongodb.SuffixCollectionNamesTest"))

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceSpec.scala
@@ -1,23 +1,34 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 import akka.pattern.CircuitBreaker
 import akka.testkit.TestKit
-import com.typesafe.config.ConfigFactory
-import org.scalatest.BeforeAndAfterAll
+import com.typesafe.config.{ ConfigFactory, ConfigValueFactory }
 import reactivemongo.api.collections.bson.BSONCollection
 import reactivemongo.bson.BSONDocument
+import play.api.libs.iteratee._
 
 import scala.concurrent._
 import scala.concurrent.duration._
 
-trait RxMongoPersistenceSpec extends MongoPersistenceSpec[RxMongoDriver, BSONCollection] with BeforeAndAfterAll { self: TestKit =>
-
-  override def afterAll() = {
-    cleanup()
-    super.afterAll()
-  }
+trait RxMongoPersistenceSpec extends MongoPersistenceSpec[RxMongoDriver, BSONCollection] { self: TestKit =>
 
   class SpecDriver extends RxMongoDriver(system, ConfigFactory.empty()) {
+    override def mongoUri = s"mongodb://$host:$noAuthPort/$embedDB"
+
+    override lazy val breaker = CircuitBreaker(system.scheduler, 0, 10.seconds, 10.seconds)
+  }
+
+  class ExtendedSpecDriver extends RxMongoDriver(system, ConfigFactory.empty()
+    .withValue("akka.contrib.persistence.mongodb.mongo.use-suffixed-collection-names", ConfigValueFactory.fromAnyRef(true))
+    .withValue("akka.contrib.persistence.mongodb.mongo.suffix-builder.class",
+      ConfigValueFactory.fromAnyRef("akka.contrib.persistence.mongodb.SuffixCollectionNamesTest"))
+    .withValue("akka.contrib.persistence.mongodb.mongo.suffix-builder.separator", ConfigValueFactory.fromAnyRef("_"))) {
     override def mongoUri = s"mongodb://$host:$noAuthPort/$embedDB"
 
     override lazy val breaker = CircuitBreaker(system.scheduler, 0, 10.seconds, 10.seconds)
@@ -26,26 +37,72 @@ trait RxMongoPersistenceSpec extends MongoPersistenceSpec[RxMongoDriver, BSONCol
   val driver = new SpecDriver
   lazy val specDb = driver.db
 
+  val extendedDriver = new ExtendedSpecDriver
+  lazy val extendedSpecDb = extendedDriver.db
+
   def withCollection(name: String)(testCode: BSONCollection => Any): Unit = {
     val collection = specDb[BSONCollection](name)
     try {
       testCode(collection)
       ()
     } finally {
-      Await.ready(collection.drop(),3.seconds)
+      Await.ready(collection.drop(), 3.seconds)
+      ()
+    }
+  }
+
+  def withSuffixedCollection(name: String)(testCode: BSONCollection => Any): Unit = {
+    val collection = extendedSpecDb[BSONCollection](name)
+    try {
+      testCode(collection)
+      ()
+    } finally {
+      Await.ready(collection.drop(), 3.seconds)
+      ()
+    }
+  }
+
+  def withJournalCollections(testCode: RxMongoDriver => Any): Unit = {
+    try {
+      testCode(extendedDriver)
+      ()
+    } finally {
+      extendedDriver.getJournalCollections().through(Enumeratee.mapM(coll => coll.drop)).run(Iteratee.foreach { _ => () })
+      ()
+    }
+  }
+
+  def withSnapshotCollections(testCode: RxMongoDriver => Any): Unit = {
+    try {
+      testCode(extendedDriver)
+      ()
+    } finally {
+      extendedDriver.getSnapshotCollections().through(Enumeratee.mapM(coll => coll.drop)).run(Iteratee.foreach { _ => () })
       ()
     }
   }
 
   def withEmptyJournal(testCode: BSONCollection => Any) = withCollection(driver.journalCollectionName) { coll =>
-    Await.result(coll.remove(BSONDocument.empty),3.seconds)
+    Await.result(coll.remove(BSONDocument.empty), 3.seconds)
     testCode(coll)
   }
 
   def withJournal(testCode: BSONCollection => Any) =
     withCollection(driver.journalCollectionName)(testCode)
 
+  def withSuffixedJournal(suffix: String)(testCode: BSONCollection => Any) =
+    withSuffixedCollection(extendedDriver.getJournalCollectionName(suffix))(testCode)
+
+  def withAutoSuffixedJournal(testCode: RxMongoDriver => Any) =
+    withJournalCollections(testCode)
+
   def withSnapshot(testCode: BSONCollection => Any) =
     withCollection(driver.snapsCollectionName)(testCode)
+
+  def withSuffixedSnapshot(suffix: String)(testCode: BSONCollection => Any) =
+    withSuffixedCollection(extendedDriver.getSnapsCollectionName(suffix))(testCode)
+
+  def withAutoSuffixedSnapshot(testCode: RxMongoDriver => Any) =
+    withSnapshotCollections(testCode)
 
 }

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceSpec.scala
@@ -34,7 +34,6 @@ trait RxMongoPersistenceSpec extends MongoPersistenceSpec[RxMongoDriver, BSONCol
     .withValue("akka.contrib.persistence.mongodb.rxmongo.failover.retries", ConfigValueFactory.fromAnyRef(10))
     .withValue("akka.contrib.persistence.mongodb.rxmongo.failover.growth", ConfigValueFactory.fromAnyRef("con"))
     .withValue("akka.contrib.persistence.mongodb.rxmongo.failover.factor", ConfigValueFactory.fromAnyRef(1))
-    .withValue("akka.contrib.persistence.mongodb.mongo.use-suffixed-collection-names", ConfigValueFactory.fromAnyRef(true))
     .withValue("akka.contrib.persistence.mongodb.mongo.suffix-builder.class",
       ConfigValueFactory.fromAnyRef("akka.contrib.persistence.mongodb.SuffixCollectionNamesTest"))
     .withValue("akka.contrib.persistence.mongodb.mongo.suffix-builder.separator", ConfigValueFactory.fromAnyRef("_"))) {

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceSpec.scala
@@ -18,13 +18,24 @@ import scala.concurrent.duration._
 
 trait RxMongoPersistenceSpec extends MongoPersistenceSpec[RxMongoDriver, BSONCollection] { self: TestKit =>
 
-  class SpecDriver extends RxMongoDriver(system, ConfigFactory.empty()) {
+  class SpecDriver extends RxMongoDriver(system, ConfigFactory.empty()
+    .withValue("akka.contrib.persistence.mongodb.rxmongo.failover.initialDelay", ConfigValueFactory.fromAnyRef("300ms"))
+    .withValue("akka.contrib.persistence.mongodb.rxmongo.failover.retries", ConfigValueFactory.fromAnyRef(15))
+    .withValue("akka.contrib.persistence.mongodb.rxmongo.failover.growth", ConfigValueFactory.fromAnyRef("con"))
+    .withValue("akka.contrib.persistence.mongodb.rxmongo.failover.factor", ConfigValueFactory.fromAnyRef(1))
+    .withValue("akka.test.default-timeout", ConfigValueFactory.fromAnyRef("5 seconds"))
+      ) {
     override def mongoUri = s"mongodb://$host:$noAuthPort/$embedDB"
 
     override lazy val breaker = CircuitBreaker(system.scheduler, 0, 10.seconds, 10.seconds)
   }
 
   class ExtendedSpecDriver extends RxMongoDriver(system, ConfigFactory.empty()
+    .withValue("akka.contrib.persistence.mongodb.rxmongo.failover.initialDelay", ConfigValueFactory.fromAnyRef("300ms"))
+    .withValue("akka.contrib.persistence.mongodb.rxmongo.failover.retries", ConfigValueFactory.fromAnyRef(15))
+    .withValue("akka.contrib.persistence.mongodb.rxmongo.failover.growth", ConfigValueFactory.fromAnyRef("con"))
+    .withValue("akka.contrib.persistence.mongodb.rxmongo.failover.factor", ConfigValueFactory.fromAnyRef(1))
+    .withValue("akka.test.default-timeout", ConfigValueFactory.fromAnyRef("5 seconds"))
     .withValue("akka.contrib.persistence.mongodb.mongo.use-suffixed-collection-names", ConfigValueFactory.fromAnyRef(true))
     .withValue("akka.contrib.persistence.mongodb.mongo.suffix-builder.class",
       ConfigValueFactory.fromAnyRef("akka.contrib.persistence.mongodb.SuffixCollectionNamesTest"))

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceSpec.scala
@@ -19,8 +19,8 @@ import scala.concurrent.duration._
 trait RxMongoPersistenceSpec extends MongoPersistenceSpec[RxMongoDriver, BSONCollection] { self: TestKit =>
 
   class SpecDriver extends RxMongoDriver(system, ConfigFactory.empty()
-    .withValue("akka.contrib.persistence.mongodb.rxmongo.failover.initialDelay", ConfigValueFactory.fromAnyRef("300ms"))
-    .withValue("akka.contrib.persistence.mongodb.rxmongo.failover.retries", ConfigValueFactory.fromAnyRef(15))
+    .withValue("akka.contrib.persistence.mongodb.rxmongo.failover.initialDelay", ConfigValueFactory.fromAnyRef("750ms"))
+    .withValue("akka.contrib.persistence.mongodb.rxmongo.failover.retries", ConfigValueFactory.fromAnyRef(10))
     .withValue("akka.contrib.persistence.mongodb.rxmongo.failover.growth", ConfigValueFactory.fromAnyRef("con"))
     .withValue("akka.contrib.persistence.mongodb.rxmongo.failover.factor", ConfigValueFactory.fromAnyRef(1))
       ) {
@@ -30,8 +30,8 @@ trait RxMongoPersistenceSpec extends MongoPersistenceSpec[RxMongoDriver, BSONCol
   }
 
   class ExtendedSpecDriver extends RxMongoDriver(system, ConfigFactory.empty()
-    .withValue("akka.contrib.persistence.mongodb.rxmongo.failover.initialDelay", ConfigValueFactory.fromAnyRef("300ms"))
-    .withValue("akka.contrib.persistence.mongodb.rxmongo.failover.retries", ConfigValueFactory.fromAnyRef(15))
+    .withValue("akka.contrib.persistence.mongodb.rxmongo.failover.initialDelay", ConfigValueFactory.fromAnyRef("750ms"))
+    .withValue("akka.contrib.persistence.mongodb.rxmongo.failover.retries", ConfigValueFactory.fromAnyRef(10))
     .withValue("akka.contrib.persistence.mongodb.rxmongo.failover.growth", ConfigValueFactory.fromAnyRef("con"))
     .withValue("akka.contrib.persistence.mongodb.rxmongo.failover.factor", ConfigValueFactory.fromAnyRef(1))
     .withValue("akka.contrib.persistence.mongodb.mongo.use-suffixed-collection-names", ConfigValueFactory.fromAnyRef(true))

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoReadJournalSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoReadJournalSpec.scala
@@ -6,6 +6,6 @@
 
 package akka.contrib.persistence.mongodb
 
-class RxMongoReadJournalSpec extends ReadJournalSpec(classOf[RxMongoPersistenceExtension], "rxmongo")
+class RxMongoReadJournalSpec extends ReadJournalSpec(classOf[RxMongoPersistenceExtension], "rxmongo", RxMongoConfigTest.rxMongoConfig)
 
-class RxMongoSuffixReadJournalSpec extends ReadJournalSpec(classOf[RxMongoPersistenceExtension], "rxmongo", SuffixCollectionNamesTest.extendedConfig)
+class RxMongoSuffixReadJournalSpec extends ReadJournalSpec(classOf[RxMongoPersistenceExtension], "rxmongo", SuffixCollectionNamesTest.rxMongoExtendedConfig)

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoReadJournalSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoReadJournalSpec.scala
@@ -1,3 +1,11 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 class RxMongoReadJournalSpec extends ReadJournalSpec(classOf[RxMongoPersistenceExtension], "rxmongo")
+
+class RxMongoSuffixReadJournalSpec extends ReadJournalSpec(classOf[RxMongoPersistenceExtension], "rxmongo", SuffixCollectionNamesTest.extendedConfig)

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoSnapshotterSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoSnapshotterSpec.scala
@@ -1,8 +1,14 @@
+/* 
+ * Contributions:
+ * Jean-Francois GUENA: implement "suffixed collection name" feature (issue #39 partially fulfilled)
+ * ...
+ */
+
 package akka.contrib.persistence.mongodb
 
 import akka.actor.ActorSystem
 import akka.contrib.persistence.mongodb.RxMongoSerializers.RxMongoSnapshotSerialization
-import akka.persistence.{SnapshotMetadata, SelectedSnapshot}
+import akka.persistence.{ SnapshotMetadata, SelectedSnapshot }
 import akka.serialization.SerializationExtension
 import akka.testkit._
 import org.junit.runner.RunWith
@@ -21,37 +27,111 @@ class RxMongoSnapshotterSpec extends TestKit(ActorSystem("unit-test")) with RxMo
   implicit val serializer = new RxMongoSnapshotSerialization()
   implicit val as = system
 
-  "A rxmongo snapshotter" should "support legacy snapshots" in { withSnapshot { ss =>
+  val suffix = "unit-test"
 
-    val metadata = (1L to 10L).map(i => SnapshotMetadata("p-1",i,i))
-    val snapshots = metadata.map(SelectedSnapshot(_,"snapshot"))
-    val legacyDocs = snapshots.map(serializer.legacyWrite)
+  "A rxmongo snapshotter" should "support legacy snapshots" in {
+    withSnapshot { ss =>
 
-    Await.result(ss.bulkInsert(legacyDocs.toStream, ordered = true),3.seconds.dilated).n should be (metadata.size)
+      val metadata = (1L to 10L).map(i => SnapshotMetadata("p-1", i, i))
+      val snapshots = metadata.map(SelectedSnapshot(_, "snapshot"))
+      val legacyDocs = snapshots.map(serializer.legacyWrite)
 
-    val extracted = ss.find(BSONDocument()).cursor[SelectedSnapshot]().collect[List](stopOnError = true)
-    val result = Await.result(extracted,3.seconds)
-    result.size should be (10)
-    result.head.metadata.persistenceId should be ("p-1")
-    ()
-  }}
+      Await.result(ss.bulkInsert(legacyDocs.toStream, ordered = true), 3.seconds.dilated).n should be(metadata.size)
 
-  it should "support mixed snapshots" in { withSnapshot { ss =>
-
-    val metadata = (1L to 10L).map(i => SnapshotMetadata("p-1",i,i))
-    val snapshots = metadata.map(SelectedSnapshot(_,"snapshot"))
-    val legacyDocs = snapshots.take(5).map(serializer.legacyWrite)
-    val newDocs = snapshots.drop(5).map(serializer.write)
-
-    Await.result(ss.bulkInsert((legacyDocs ++ newDocs).toStream, ordered = true),3.seconds).n should be (metadata.size)
-
-    val extracted = ss.find(BSONDocument()).cursor[SelectedSnapshot]().collect[List](stopOnError = true)
-    val result = Await.result(extracted,3.seconds.dilated)
-    result.size should be (10)
-    result.foreach { sn =>
-      sn.metadata.persistenceId should be ("p-1")
+      val extracted = ss.find(BSONDocument()).cursor[SelectedSnapshot]().collect[List](stopOnError = true)
+      val result = Await.result(extracted, 3.seconds)
+      result.size should be(10)
+      result.head.metadata.persistenceId should be("p-1")
+      ()
     }
-    ()
-  }}
+  }
+
+  it should "support legacy snapshots in suffixed snapshot collection" in {
+    withSuffixedSnapshot(suffix) { ss =>
+
+      val metadata = (1L to 10L).map(i => SnapshotMetadata("p-1", i, i))
+      val snapshots = metadata.map(SelectedSnapshot(_, "snapshot"))
+      val legacyDocs = snapshots.map(serializer.legacyWrite)
+
+      Await.result(ss.bulkInsert(legacyDocs.toStream, ordered = true), 3.seconds.dilated).n should be(metadata.size)
+
+      // should 'retrieve' (and not 'build') the suffixed snapshot 
+      val snapsName = extendedDriver.getSnapsCollectionName(suffix)
+      val collections = Await.result(extendedDriver.db.collectionNames, 3.seconds)
+      collections.contains(snapsName) should be (true)
+
+      val extracted = ss.find(BSONDocument()).cursor[SelectedSnapshot]().collect[List](stopOnError = true)
+      val result = Await.result(extracted, 3.seconds)
+      result.size should be(10)
+      result.head.metadata.persistenceId should be("p-1")
+      ()
+    }
+  }
+
+  it should "support mixed snapshots" in {
+    withSnapshot { ss =>
+
+      val metadata = (1L to 10L).map(i => SnapshotMetadata("p-1", i, i))
+      val snapshots = metadata.map(SelectedSnapshot(_, "snapshot"))
+      val legacyDocs = snapshots.take(5).map(serializer.legacyWrite)
+      val newDocs = snapshots.drop(5).map(serializer.write)
+
+      Await.result(ss.bulkInsert((legacyDocs ++ newDocs).toStream, ordered = true), 3.seconds).n should be(metadata.size)
+
+      val extracted = ss.find(BSONDocument()).cursor[SelectedSnapshot]().collect[List](stopOnError = true)
+      val result = Await.result(extracted, 3.seconds.dilated)
+      result.size should be(10)
+      result.foreach { sn =>
+        sn.metadata.persistenceId should be("p-1")
+      }
+      ()
+    }
+  }
+
+  it should "support mixed snapshots in suffixed snapshot collection" in {
+    withSuffixedSnapshot(suffix) { ss =>
+
+      val metadata = (1L to 10L).map(i => SnapshotMetadata("p-1", i, i))
+      val snapshots = metadata.map(SelectedSnapshot(_, "snapshot"))
+      val legacyDocs = snapshots.take(5).map(serializer.legacyWrite)
+      val newDocs = snapshots.drop(5).map(serializer.write)
+
+      Await.result(ss.bulkInsert((legacyDocs ++ newDocs).toStream, ordered = true), 3.seconds).n should be(metadata.size)
+       
+      val snapsName = extendedDriver.getSnapsCollectionName(suffix)
+      val collections = Await.result(extendedDriver.db.collectionNames, 3.seconds)
+      collections.contains(snapsName) should be (true)
+      
+      val extracted = ss.find(BSONDocument()).cursor[SelectedSnapshot]().collect[List](stopOnError = true)
+      val result = Await.result(extracted, 3.seconds.dilated)
+      result.size should be(10)
+      result.foreach { sn =>
+        sn.metadata.persistenceId should be("p-1")
+      }
+      ()
+    }
+  }
+
+  it should "save snapshot in suffixed snapshot collection" in {
+    withAutoSuffixedSnapshot { drv =>
+      
+      val underExtendedTest = new RxMongoSnapshotter(drv)
+      
+      // should 'build' the suffixed snapshot
+      Await.ready(new RxMongoSnapshotter(drv).saveSnapshot(SelectedSnapshot(SnapshotMetadata(suffix, 4, 1000), "snapshot-payload")), 3.seconds)
+
+      // should 'retrieve' (and not 'build') the suffixed snapshot 
+      val snapsName = drv.getSnapsCollectionName(suffix)
+      val collections = Await.result(drv.db.collectionNames, 3.seconds)
+      collections.contains(snapsName) should be (true)
+      val ss = drv.getSnaps(suffix)
+
+      val extracted = ss.find(BSONDocument()).cursor[SelectedSnapshot]().collect[List](stopOnError = true)
+      val result = Await.result(extracted, 3.seconds.dilated)
+      result.size should be(1)
+      result.head.metadata.persistenceId should be(suffix)
+      ()
+    }
+  }
 
 }

--- a/test_containers.sh
+++ b/test_containers.sh
@@ -8,8 +8,8 @@ docker pull scullxbones/mongodb:$MONGODB_VERSION
 docker ps -a | grep scullxbones/mongodb | awk '{print $1}' | xargs docker rm -f
 sleep 3
 
-docker run -d -p $MONGODB_NOAUTH_PORT:27017 scullxbones/mongodb:$MONGODB_VERSION --noauth
-docker run -d -p $MONGODB_AUTH_PORT:27017 scullxbones/mongodb:$MONGODB_VERSION --auth
+docker run -d -p $MONGODB_NOAUTH_PORT:27017 scullxbones/mongodb:$MONGODB_VERSION --noauth --storageEngine wiredTiger
+docker run -d -p $MONGODB_AUTH_PORT:27017 scullxbones/mongodb:$MONGODB_VERSION --auth --storageEngine wiredTiger
 
 sleep 3
 docker exec $(docker ps -a | grep -e "--auth" | awk '{print $1;}') mongo admin --eval "db.createUser({user:'admin',pwd:'password',roles:['root']});"


### PR DESCRIPTION
Here is a little explanation about what has be done for this Pull Request.

First of all, I added *contribution* headers to all files I have contributed to. This is mandatory, according to my company policy about sharing open source code. BTW, I had to wait for a GO/NoGO before submitting this PR, that's why it took so long...

This PR implements a *suffixed collection names* feature in order to **partially** fulfill issue #39 requirement.

`akka_persistence_journal` and `akka_persistence_snapshots` collections may exist (their suffix is emty) and we can now create `akka_persistence_journal_some_suffix` and `akka_persistence_snapshots_some_suffix` collections. Their indexes are suffixed too. Capped collection `akka_persistence_realtime` and metadata collection `akka_persistence_metadata` are **never** suffixed.

Suffix is built after `persistenceId` through an end-user function named `getSuffixFromPersistenceId`, contained in a new `CanSuffixCollectionNames` trait, defined in *MongoPersistence.scala* file. By default, the function returns an empty string, meaning that no suffix is added to any collection. In order to actually add a suffix, the user has to override this function in some class extending `CanSuffixCollectionNames` trait.

Following (heavily) commented lines have been added to *reference.conf* file:
```
akka {
  contrib {
    persistence {
      mongodb {
        mongo {
        ...
          # set to true for using suffixed collection names
          use-suffixed-collection-names = false
          suffix-builder {
            # available only when use-suffixed-collection-names is true
            
            # This character is used as a separator before suffix in collection names
            # If you provide a string longer than one character, its first character only will be used
            # If you provide an empty string, the default underscore (_) character will be used
            separator = "_"
            
            # extend 'akka.contrib.persistence.mongodb.CanSuffixCollectionNames' trait,
            # override its method, and provide its complete path in the 'class' field below.
            # Notice that the default "akka.contrib.persistence.mongodb.SuffixCollectionNames"
            # does NOT suffix collection names as it always return an empty string
            class = "akka.contrib.persistence.mongodb.SuffixCollectionNames"
          }
          ...
        }
      }
    }
  }
}
```

In case the user only turns `akka.contrib.persistence.mongodb.mongo.use-suffixed-collection-names` to *true*, nothing happens if he does not implement any class extending `CanSuffixCollectionNames` trait.

The user may choose a separator (*underscore* by default) limited to one character (mongoDB does not allow more than 64 characters for collection names, so lets keep this separator short)

Finally, the user has to provide the complete path to its class extending `CanSuffixCollectionNames` trait. All of this is documented at the bottom of *akka24.md* file.

Let's have a look at the code now:

Basically, everywhere we have to use the journal, instead of simply calling `journal`, we use a `getJournal(persistenceId)` method and apply the original code to it. There is an exception in `batchAppend` methods, where we use `journal(persistenceId)` to create indexes for the journal in the same way original `journal` lazy value created them. This lazy value was called only once of course, which is not the case for `journal(persistenceId)`, called every time we insert events in the database. But it's OK as the mongoDB methods used in `ensureIndex` in both *CasbahPersistenceExtension.scala* and *RxMongoPersistenceExtension.scala* files do nothing if index already exists, so we do not erase nor corrupt any existing index. Notice that the lazy value still exists and simply calls `journal("")`, creating the default unsuffixed journal and, as it remains a lazy value, it is called only once...

In other words, `getJournal(persistenceId)` *retrieves* a journal while `journal(persistenceId)` *builds* it along with its indexes. This is exactly the same for snapshots where we have a `getSnaps(persistenceId)` that *retrieves* a snapshot while `snaps(persistenceId)` *builds* it along with its indexes, and the latter is used only in `saveSnapshot` methods. As we often have to retrieve collection **names** (not collections thewselves) we have new convenient methods like `getJournalCollectionName(persistenceId)`, `getJournalIndexName(persistenceId)` etc...

A word about `batchAppend(writes)` method: Since events have now to be recorded in different collections, we *group* them by `persistenceId` **before** *bulk inserting* them in appropriate collection. That way, we work collection by collection instead of event by event, and avoid "jumping" from one collection to the other when we parse events. And because capped collections are not suffixed, we had to separate the *journal* batch append from the *realtime* one, giving birth to two new methods, `doBatchJournalAppend(writes, journal)` and `doBatchRealtimeAppend(writes)`. From now on, `batchAppend` groups events by `persistenceId`, calls `doBatchJournalAppend` for each group, and finally calls `doBatchRealtimeAppend` for all events.

A word about `upgradeJournalIfNeeded()` method: This method may be called at journal creation, by `journal(persistenceId)` now, to migrate journal from *0.x* to *1.x*. Because journal may depend on `persistenceId`, the method became `upgradeJournalIfNeeded(persistenceId)`, even if we cannot imagine someone migrating a **unique** *0.x* journal to **many** *1.x* suffixed journals...

On the write side, `PersistenceId` is retrieved from `AtomicWrite` objects when journalling and `SnapshotMetadata` objects when snapshotting. This way, we can call the right journal (or snapshot) and apply the original code to it. On the read side, we have to "parse" all journals, except for the *"XXXbyPersistenceId"* methods where we directly retrieve the right journal using `getJournal(persistenceId)`. So, we have now two more methods: `getJournalCollections()` and `getSnapshotCollections()` (the latter is not used yet, but who knows in the future...)

What is missing ?

For now, the *suffixed collection names* feature should be applied to **new databases**. Some migration process from a **unique** *1.x* journal + snapshot to **many** *1.x* suffixed collections does not exist yet, this is the next step. We can imagine some `akka.contrib.persistence.mongodb.mongo.collections-automatic-suffix` option working the same way `akka.contrib.persistence.mongodb.mongo.journal-automatic-upgrade` option works, plus the mandatory class extending `CanSuffixCollectionNames` trait described above, and a new `suffixCollectionsIfNeeded` method that should:
 * record each event of existing journal in appropriate suffixed journal,
 * record each event of existing snapshot in appropriate suffixed snapshot,
 * delete *old* journal and snapshot...


