### PR TITLE
fix the #119 issue

### DIFF
--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoReadJournaller.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoReadJournaller.scala
@@ -66,7 +66,7 @@ trait IterateeActorPublisher[T] extends ActorPublisher[T] with ActorLogging {
 
   def defaults: Receive = {
     case _: Cancel | SubscriptionTimeoutExceeded =>
-      log.warning(s"Cancelling stream")
+      log.warning("Cancelling stream")
       onCompleteThenStop()
       cleanup().pipeTo(self)
       ()
@@ -148,14 +148,10 @@ class CurrentAllPersistenceIds(val driver: RxMongoDriver) extends IterateeActorP
 
   override def cleanup() = {
     import reactivemongo.api.commands.bson.DefaultBSONCommandError
-    driver.collection(temporaryCollectionName).drop().recover {
+    temporaryCollection.drop().recover {
       // we ignore the "ns not found" error which is NOT filtered out by ReactiveMongo when trying to drop a non existing collection
       // see https://github.com/ReactiveMongo/ReactiveMongo/issues/205
-      case commandError: DefaultBSONCommandError => {
-        commandError.errmsg match {
-          case Some(str) if str.equals("ns not found") => ()
-        }
-      }
+      case commandError: DefaultBSONCommandError if commandError.errmsg.contains("ns not found") => ()
     }.map(_ => ADone)
   }
 

--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoReadJournaller.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoReadJournaller.scala
@@ -147,7 +147,6 @@ class CurrentAllPersistenceIds(val driver: RxMongoDriver) extends IterateeActorP
   val temporaryCollection = driver.collection(temporaryCollectionName)
 
   override def cleanup() = {
-    driver.collection(temporaryCollectionName).drop().map(_ => ADone)
     import reactivemongo.api.commands.bson.DefaultBSONCommandError
     driver.collection(temporaryCollectionName).drop().recover {
       // we ignore the "ns not found" error which is NOT filtered out by ReactiveMongo when trying to drop a non existing collection

--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoReadJournaller.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoReadJournaller.scala
@@ -148,6 +148,16 @@ class CurrentAllPersistenceIds(val driver: RxMongoDriver) extends IterateeActorP
 
   override def cleanup() = {
     driver.collection(temporaryCollectionName).drop().map(_ => ADone)
+    import reactivemongo.api.commands.bson.DefaultBSONCommandError
+    driver.collection(temporaryCollectionName).drop().recover {
+      // we ignore the "ns not found" error which is NOT filtered out by ReactiveMongo when trying to drop a non existing collection
+      // see https://github.com/ReactiveMongo/ReactiveMongo/issues/205
+      case commandError: DefaultBSONCommandError => {
+        commandError.errmsg match {
+          case Some(str) if str.equals("ns not found") => ()
+        }
+      }
+    }.map(_ => ADone)
   }
 
   private val flattened = Enumeratee.mapConcat[BSONDocument](_.getAs[String]("_id").toSeq)


### PR DESCRIPTION
Hello,

According to [this issue](https://github.com/ReactiveMongo/ReactiveMongo/issues/205) it seems that the Drop command implemented in ReactiveMongo does not filter out the "ns not found" error message in case the collection does not exist.

I could check this by adding a `printStackTrace` in the *RxMongoReadJournaller.scala* file at the `Status.Failure` message handling level (between lines 74 and 75) when running the `RxMongoSuffixReadJournalSpec` tests. Of course, after I finished testing, I removed that `printStackTrace`...

So, I updated the overridden `cleanup()` method in `CurrentAllPersistenceIds` class in order to handle the "ns not found" special error case, and there is no more `"onError must not be called after onComplete"` exception when I run the tests.

Hope this helps...