### PR TITLE
Add serializer id to the journal

### DIFF
--- a/common/src/main/scala/akka/contrib/persistence/mongodb/MongoJournal.scala
+++ b/common/src/main/scala/akka/contrib/persistence/mongodb/MongoJournal.scala
@@ -141,6 +141,7 @@ trait JournallingFieldNames {
   final val TYPE = "_t"
   final val HINT = "_h"
   final val SER_MANIFEST = "_sm"
+  final val SER_ID = "_si"
 }
 object JournallingFieldNames extends JournallingFieldNames
 


### PR DESCRIPTION
Fixes #137 by adding an optional `_si` field. It keep the back compatibility with the old behavior. We should consider increase the version and run a migration.