### PR TITLE
Support rxmongo 0.12.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
    - docker
 language: scala
 scala:
-   - 2.11.7
+   - 2.11.8
 env:
   matrix:
     - MONGODB_VERSION=2.6
@@ -24,4 +24,4 @@ before_script:
   - sleep 15
   - docker exec $(docker ps -a | grep -e "--auth" | awk '{print $1;}') mongo admin --eval "db.createUser({user:'admin',pwd:'password',roles:['root']});"
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION -Dakka.test.timefactor=10 test
+  - travis_wait sbt ++$TRAVIS_SCALA_VERSION -Dakka.test.timefactor=10 test

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,10 @@
-val releaseV = "1.3.7"
+val releaseV = "1.4.0"
 
-val scalaV = "2.11.7"
+val scalaV = "2.11.8"
 
 scalaVersion := scalaV
 
-val AkkaV = "2.4.10"
+val AkkaV = "2.4.17"
 
 val commonDeps = Seq(
   ("com.typesafe.akka"  %% "akka-persistence" % AkkaV % "provided")
@@ -84,7 +84,9 @@ lazy val `akka-persistence-mongo-rxmongo` = (project in file("rxmongo"))
   .settings(commonSettings:_*)
   .settings(
     libraryDependencies ++= Seq(
-      ("org.reactivemongo" %% "reactivemongo" % "0.11.14" % "provided")
+      ("org.reactivemongo" %% "reactivemongo" % "0.12.1" % "provided")
+        .exclude("com.typesafe.akka","akka-actor_2.11"),
+      ("org.reactivemongo" %% "reactivemongo-akkastream" % "0.12.1" % "provided")
         .exclude("com.typesafe.akka","akka-actor_2.11")
     )
   )

--- a/common/src/test/scala/akka/contrib/persistence/mongodb/JournalLoadSpec.scala
+++ b/common/src/test/scala/akka/contrib/persistence/mongodb/JournalLoadSpec.scala
@@ -10,7 +10,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import akka.actor._
 import akka.testkit._
-import akka.persistence.PersistentActor
+import akka.persistence.{PersistentActor, Recovery}
 import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfterAll
 
@@ -73,6 +73,12 @@ abstract class JournalLoadSpec(extensionClass: Class[_], database: String, exten
 
     override def receiveRecover: Receive = {
       case x:Int => (1 to x).foreach(_ => state.event(IncEvent))
+    }
+
+    override def onRecoveryFailure(cause: Throwable, event: Option[Any]): Unit = {
+      log.error(cause,s"FAILED TO RECOVER during load test due to event of type ${event.map(_.getClass)}: $event")
+
+      super.onRecoveryFailure(cause, event)
     }
 
     private def eventHandler(int: Int): Unit = {

--- a/common/src/test/scala/akka/contrib/persistence/mongodb/MongoPersistenceSpec.scala
+++ b/common/src/test/scala/akka/contrib/persistence/mongodb/MongoPersistenceSpec.scala
@@ -14,7 +14,7 @@ import scala.concurrent.ExecutionContext
 trait MongoPersistenceSpec[D,C] extends BaseUnitTest with ContainerMongo with BeforeAndAfterAll { self: TestKit =>
 
   implicit val callerRuns = new ExecutionContext {
-    def reportFailure(t: Throwable): Unit = { t.printStackTrace() }
+    def reportFailure(t: Throwable): Unit = { throw t }
     def execute(runnable: Runnable): Unit = { runnable.run() }
   }
 

--- a/common/src/test/scala/akka/contrib/persistence/mongodb/ReadJournalSpec.scala
+++ b/common/src/test/scala/akka/contrib/persistence/mongodb/ReadJournalSpec.scala
@@ -9,18 +9,18 @@ package akka.contrib.persistence.mongodb
 import akka.actor.Props
 import akka.persistence.PersistentActor
 import akka.persistence.query.{EventEnvelope, PersistenceQuery}
-import akka.stream.scaladsl.{GraphDSL, Merge, RunnableGraph, Sink}
-import akka.stream.{ActorMaterializer, ClosedShape}
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Sink
 import akka.testkit._
 import com.mongodb.client.model.{BulkWriteOptions, InsertOneModel}
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{Config, ConfigFactory}
 import org.bson.Document
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
+import scala.collection.JavaConverters._
 import scala.concurrent.{Await, Future, Promise}
 import scala.util.Random
-import scala.collection.JavaConverters._
 
 abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: Class[A], dbName: String, extendedConfig: String = "|") extends BaseUnitTest with ContainerMongo with BeforeAndAfterAll with BeforeAndAfter with Eventually {
 
@@ -28,7 +28,7 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
 
   override def embedDB = s"read-journal-test-$dbName"
 
-  override def afterAll() = cleanup()
+  override def afterAll(): Unit = cleanup()
 
   before {
     val collIterator = mongoClient.getDatabase(embedDB).listCollectionNames().iterator()
@@ -39,7 +39,7 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
     }
   }
 
-  def config(extensionClass: Class[_]) = ConfigFactory.parseString(s"""
+  def config(extensionClass: Class[_]): Config = ConfigFactory.parseString(s"""
     |akka.contrib.persistence.mongodb.mongo.driver = "${extensionClass.getName}"
     |akka.contrib.persistence.mongodb.mongo.mongouri = "mongodb://$host:$noAuthPort/$embedDB"
     |akka.persistence.journal.plugin = "akka-contrib-mongodb-persistence-journal"
@@ -59,24 +59,24 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
     $extendedConfig
     |""".stripMargin).withFallback(ConfigFactory.defaultReference())
 
-  def suffixCollNamesEnabled = config(extensionClass).getString("akka.contrib.persistence.mongodb.mongo.suffix-builder.class") != null &&
+  def suffixCollNamesEnabled: Boolean = config(extensionClass).getString("akka.contrib.persistence.mongodb.mongo.suffix-builder.class") != null &&
     !config(extensionClass).getString("akka.contrib.persistence.mongodb.mongo.suffix-builder.class").trim.isEmpty
 
-  def props(id: String, promise: Promise[Unit]) = Props(new Persistent(id, promise))
+  def props(id: String, promise: Promise[Unit], eventCount: Int) = Props(new PersistentCountdown(id, promise, eventCount))
 
   case class Append(s: String)
 
-  class Persistent(val persistenceId: String, completed: Promise[Unit]) extends PersistentActor {
-    var events = Vector.empty[String]
+  class PersistentCountdown(val persistenceId: String, completed: Promise[Unit], count: Int) extends PersistentActor {
+    private var remaining = count
 
     override def receiveRecover: Receive = {
-      case s: String => events = events :+ s
+      case _: String => remaining -= 1
     }
 
     override def receiveCommand: Receive = {
-      case Append(s) => persist(s) { str =>
-        events = events :+ str
-        if (str == "END") {
+      case Append(s) => persist(s) { _ =>
+        remaining -= 1
+        if (remaining == 0) {
           completed.success(())
           context.stop(self)
         }
@@ -93,7 +93,7 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
       val events = "this" :: "is" :: "just" :: "a" :: "test" :: "END" :: Nil
 
       val promise = Promise[Unit]()
-      val ar = as.actorOf(props("foo", promise))
+      val ar = as.actorOf(props("foo", promise, 6))
 
       events map Append.apply foreach (ar ! _)
 
@@ -121,26 +121,20 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
 
       val promise1 = Promise[Unit]()
       val promise2 = Promise[Unit]()
-      val ar1 = as.actorOf(props("foo", promise1))
-      val ar2 = as.actorOf(props("bar", promise2))
+      val ar1 = as.actorOf(props("foo", promise1, 3))
+      val ar2 = as.actorOf(props("bar", promise2, 3))
 
       events slice (0, 3) foreach (ar1 ! _)
-
+      Await.ready(promise1.future, 3.seconds)
       val readJournal =
         PersistenceQuery(as).readJournalFor[ScalaDslMongoReadJournal](MongoReadJournal.Identifier)
 
       val probe = TestProbe()
 
-      val promise = Promise[Int]()
-      readJournal.allEvents().runFold(0) {
-        case (accum, ee) =>
-          if (accum == 4) promise.trySuccess(accum)
-          probe.ref ! ee
-          accum + 1
-      }
-      events slice (3, 6) foreach (ar2 ! _)
+      readJournal.allEvents().runWith(Sink.actorRef[EventEnvelope](probe.ref, 'complete))
 
-      Await.result(promise.future, 10.seconds.dilated) shouldBe 4
+      events slice (3, 6) foreach (ar2 ! _)
+      implicit val ec = as.dispatcher
 
       probe.receiveN(events.size, 10.seconds.dilated).collect { case msg: EventEnvelope => msg.event.toString } should contain allOf ("this", "is", "just", "a", "test", "END")
   }
@@ -158,8 +152,8 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
       
       allEvents foreach {case (id, evs) => 
         promises collect {
-          case (i,p) if (i == id) =>
-            val ar = as.actorOf(props(i, p), s"current-all-events-$i")
+          case (i,p) if i == id =>
+            val ar = as.actorOf(props(i, p, 5), s"current-all-events-$i")
             evs map Append.apply foreach (ar ! _)
             ar ! Append("END")
         }
@@ -194,22 +188,22 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
       implicit def patienceConfig = PatienceConfig(timeout = 5.seconds.dilated, interval = 500.millis.dilated)
 
       val promises = ("1" :: "2" :: "3" :: "4" :: "5" :: Nil).map(id => id -> Promise[Unit]())
-      val ars = promises.map { case (id, p) => as.actorOf(props(id, p), s"current-persistenceId-$id") }
+      val ars = promises.map { case (id, p) => as.actorOf(props(id, p, 1), s"current-persistenceId-$id") }
 
       val end = Append("END")
       ars foreach (_ ! end)
 
       implicit val ec = as.dispatcher
-      val futures = promises.map { case (_, p) => p.future }
-      val count = Await.result(Future.fold(futures)(0) { case (cnt, _) => cnt + 1 }, 10.seconds.dilated)
-      count shouldBe 5
+      val waitForStop = Future.sequence(promises.map { case (_, p) => p.future })
+      Await.result(waitForStop, 10.seconds.dilated) should have size 5
 
       val readJournal =
         PersistenceQuery(as).readJournalFor[ScalaDslMongoReadJournal](MongoReadJournal.Identifier)
 
-      val fut = readJournal.currentPersistenceIds().runFold(Seq.empty[String])(_ :+ _)
+      val probe = TestProbe()
+      readJournal.currentPersistenceIds().runWith(Sink.actorRef(probe.ref, 'complete))
 
-      Await.result(fut, 20.seconds.dilated) should contain allOf ("1", "2", "3", "4", "5")
+      probe.receiveN(6, 5.seconds.dilated) should contain allOf ("1", "2", "3", "4", "5")
 
       eventually {
         mongoClient.getDatabase(embedDB).listCollectionNames()
@@ -273,7 +267,7 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
       implicit def patienceConfig = PatienceConfig(timeout = 5.seconds.dilated, interval = 500.millis.dilated)
 
       val promises = ("1" :: "2" :: "3" :: "4" :: "5" :: Nil).map(id => id -> Promise[Unit]())
-      val ars = promises.map { case (id, p) => as.actorOf(props(id, p)) }
+      val ars = promises.map { case (id, p) => as.actorOf(props(id, p, 4)) }
       val events = ("this" :: "is" :: "a" :: "test" :: Nil) map Append.apply
 
       implicit val ec = as.dispatcher
@@ -283,9 +277,9 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
 
       val probe = TestProbe()
 
-      ars slice (0, 3) foreach { ar =>
-        events foreach (ar ! _)
-      }
+      ars.slice(0,3).foreach(ar =>events.foreach(ar ! _))
+
+      Await.ready(Future.sequence(promises.slice(0,3).map(_._2.future)), 5.seconds.dilated)
 
       readJournal.allPersistenceIds().runForeach { pid =>
         probe.ref ! pid
@@ -295,7 +289,8 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
         events foreach (ar ! _)
       }
 
-      probe.receiveN(ars.size, 10.seconds.dilated).collect { case x: String => x } should contain allOf ("1", "2", "3", "4", "5")
+      probe.receiveN(ars.size, 10.seconds.dilated)
+        .collect { case x: String => x } should contain allOf ("1", "2", "3", "4", "5")
 
       eventually {
         mongoClient.getDatabase(embedDB).listCollectionNames()
@@ -312,7 +307,7 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
       val events = ("this" :: "is" :: "just" :: "a" :: "test" :: "END" :: Nil) map Append.apply
 
       val promise = Promise[Unit]()
-      val ar = as.actorOf(props("foo", promise))
+      val ar = as.actorOf(props("foo", promise, 6))
 
       events foreach (ar ! _)
 
@@ -340,17 +335,20 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
         PersistenceQuery(as).readJournalFor[ScalaDslMongoReadJournal](MongoReadJournal.Identifier)
 
       val promise = Promise[Unit]()
-      val ar = as.actorOf(props("foo-live", promise))
+      val ar = as.actorOf(props("foo-live", promise, 3))
 
       val events = ("foo" :: "bar" :: "bar2" :: Nil) map Append.apply
 
       val probe = TestProbe()
 
-      readJournal.eventsByPersistenceId("foo-live", 2L, 3L).runForeach(probe.ref ! _)
+      readJournal.eventsByPersistenceId("foo-live", 2L, 3L).runWith(Sink.actorRef(probe.ref, 'complete))
 
       events foreach (ar ! _)
 
-      probe.receiveN(2, 10.seconds.dilated).collect { case msg: EventEnvelope => msg }.toList.map(_.event) should contain allOf ("bar", "bar2")
+      probe.receiveN(2, 10.seconds.dilated)
+        .collect { case msg: EventEnvelope => msg }
+        .toList
+        .map(_.event) should contain inOrderOnly("bar", "bar2")
   }
 
   it should "support the events by id query with multiple persistent actors" in withConfig(config(extensionClass), "akka-contrib-mongodb-persistence-readjournal") {
@@ -364,8 +362,8 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
 
       val promise = Promise[Unit]()
       val promise2 = Promise[Unit]()
-      val ar = as.actorOf(props("foo-live-2a", promise))
-      val ar2 = as.actorOf(props("foo-live-2b", promise2))
+      val ar = as.actorOf(props("foo-live-2a", promise, 3))
+      val ar2 = as.actorOf(props("foo-live-2b", promise2, 3))
 
       val events = ("foo" :: "bar" :: "bar2" :: Nil) map Append.apply
       val events2 = ("just" :: "a" :: "test" :: Nil) map Append.apply
@@ -377,7 +375,10 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
       events foreach (ar ! _)
       events2 foreach (ar2 ! _)
 
-      probe.receiveN(events2.size, 10.seconds.dilated).collect { case msg: EventEnvelope => msg }.toList.map(_.event) should be(events2.map(_.s))
+      probe.receiveN(events2.size, 10.seconds.dilated)
+        .collect { case msg: EventEnvelope => msg }
+        .toList
+        .map(_.event) should be(events2.map(_.s))
   }
 
   it should "support read 1k events from journal" in withConfig(config(extensionClass), "akka-contrib-mongodb-persistence-readjournal") {
@@ -391,44 +392,28 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
 
       val nrOfActors = 10
       val nrOfEvents = 100
-      val promises = (1 to nrOfActors).map(_ => Promise[Unit]()).zipWithIndex
-      val ars = promises map { case (p, idx) => system.actorOf(props(s"pid-${idx + 1}", p), s"actor-${idx + 1}") }
-      val events = (1 to nrOfEvents).map(eventId => Append.apply(s"eventd-$eventId")) :+ Append("END")
+      val promises = (1 to nrOfActors).map(idx => Promise[Unit]() -> idx)
+      val ars = promises map { case (p, idx) => system.actorOf(props(s"pid-$idx", p, nrOfEvents), s"actor-$idx") }
+      val (firstHalf, secondHalf) = (1 to nrOfEvents).map(eventId => Append(s"event-$eventId")).splitAt(50)
+
+      firstHalf foreach(ev => ars foreach (_ ! ev) )
 
       val probe = TestProbe()
 
-      val sources = (1 to nrOfActors) map (nr => readJournal.eventsByPersistenceId(s"pid-$nr", 0, Long.MaxValue).take(events.size.toLong))
+      val sources = (1 to nrOfActors) map (nr => readJournal.eventsByPersistenceId(s"pid-$nr", 0, Long.MaxValue))
 
       val sink = Sink.actorRef(probe.ref, "complete")
 
-      val merged = GraphDSL.create(sink) { implicit b =>
-        (s) =>
-          import GraphDSL.Implicits._
+      sources.reduce(_ merge _).runWith(sink)
 
-          val merge = b.add(Merge[EventEnvelope](sources.size))
-
-          sources.foldLeft(0) {
-            case (idx, src) =>
-              src ~> merge.in(idx)
-              idx + 1
-          }
-
-          merge.out ~> s
-
-          ClosedShape
-      }
-      RunnableGraph.fromGraph(merged).run()
-
-      ars foreach { ar =>
-        events foreach (ar ! _)
-      }
+      secondHalf foreach(ev => ars foreach (_ ! ev) )
 
       implicit val ec = as.dispatcher
 
       val done = Future.sequence(promises.map(_._1.future))
-      Await.result(done, 1.minute.dilated)
+      Await.result(done, 10.seconds.dilated)
 
-      probe.receiveN(nrOfActors * nrOfEvents, 1.seconds.dilated)
+      probe.receiveN(nrOfActors * nrOfEvents, 10.seconds.dilated) should have size (nrOfActors.toLong * nrOfEvents)
       ()
   }
 }

--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceExtension.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceExtension.scala
@@ -37,11 +37,15 @@ object RxMongoPersistenceDriver {
   }
 }
 
-class RxMongoDriverProvider {
-  val driver = MongoDriver()
+class RxMongoDriverProvider(actorSystem: ActorSystem) {
+  val driver: MongoDriver = {
+    val md = MongoDriver()
+    actorSystem.registerOnTermination(driver.close())
+    md
+  }
 }
 
-class RxMongoDriver(system: ActorSystem, config: Config, driverProvider: RxMongoDriverProvider = new RxMongoDriverProvider) extends MongoPersistenceDriver(system, config) {
+class RxMongoDriver(system: ActorSystem, config: Config, driverProvider: RxMongoDriverProvider) extends MongoPersistenceDriver(system, config) {
   import RxMongoPersistenceDriver._
 
   // Collection type
@@ -238,7 +242,7 @@ class RxMongoDriver(system: ActorSystem, config: Config, driverProvider: RxMongo
 
 class RxMongoPersistenceExtension(actorSystem: ActorSystem) extends MongoPersistenceExtension {
 
-  val driverProvider: RxMongoDriverProvider = new RxMongoDriverProvider
+  val driverProvider: RxMongoDriverProvider = new RxMongoDriverProvider(actorSystem)
 
   override def configured(config: Config): Configured = Configured(config)
 

--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceExtension.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceExtension.scala
@@ -6,9 +6,8 @@
 
 package akka.contrib.persistence.mongodb
 
-import java.util.concurrent.TimeUnit
-
 import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
 import akka.util.Timeout
 import com.typesafe.config.{Config, ConfigFactory}
 import play.api.libs.iteratee._
@@ -19,9 +18,8 @@ import reactivemongo.api.indexes.{Index, IndexType}
 import reactivemongo.bson._
 import reactivemongo.core.nodeset.Authenticate
 
-import scala.concurrent.duration.{Duration, FiniteDuration}
-import scala.concurrent.{Awaitable, ExecutionContext, Future}
-//import scala.language.implicitConversions
+import scala.concurrent._
+import duration._
 import scala.util.{Failure, Success}
 
 object RxMongoPersistenceDriver {
@@ -46,9 +44,6 @@ class RxMongoDriverProvider {
 class RxMongoDriver(system: ActorSystem, config: Config, driverProvider: RxMongoDriverProvider = new RxMongoDriverProvider) extends MongoPersistenceDriver(system, config) {
   import RxMongoPersistenceDriver._
 
-  import concurrent.Await
-  import concurrent.duration._
-
   // Collection type
   type C = Future[BSONCollection]
 
@@ -61,7 +56,7 @@ class RxMongoDriver(system: ActorSystem, config: Config, driverProvider: RxMongo
     case Failure(throwable) => throw throwable
   }
 
-  implicit val waitFor = 4.seconds
+  implicit val waitFor: FiniteDuration = 10.seconds
 
   private[this] lazy val unauthenticatedConnection: MongoConnection = wait {
     // create unauthenticated connection, there is no direct way to wait for authentication this way
@@ -111,7 +106,7 @@ class RxMongoDriver(system: ActorSystem, config: Config, driverProvider: RxMongo
   override private[mongodb] def upgradeJournalIfNeeded(persistenceId: String): Unit = {
     import JournallingFieldNames._
 
-    import concurrent.ExecutionContext.Implicits.global
+    import scala.concurrent.ExecutionContext.Implicits.global
 
     val j = getJournal(persistenceId)
     val walker = walk(j) _
@@ -152,12 +147,12 @@ class RxMongoDriver(system: ActorSystem, config: Config, driverProvider: RxMongo
     } yield wr
 
     eventuallyUpgrade.onComplete {
-      case Success(wrs) if wrs.exists(w => w.inError || w.hasErrors) =>
-        val errors = wrs.filter(_.inError).map(r => s"${r.code} - ${r.message}").mkString("\n")
+      case Success(wrs) if wrs.exists(w => w.writeErrors.nonEmpty || w.writeConcernError.nonEmpty) =>
+        val errors = wrs.flatMap(_.writeConcernError).map(r => s"${r.code} - ${r.errmsg}").mkString("\n")
         logger.error("Upgrade did not complete successfully")
         logger.error(s"Errors during journal auto-upgrade:\n$errors")
-        val writeErrors = wrs.filter(_.hasErrors).flatMap(_.writeErrors).map(we => s"${we.code} - ${we.errmsg}").mkString("\n")
-        logger.error(s"Received ${wrs.count(_.hasErrors)} write errors during journal auto-upgrade:\n$writeErrors")
+        val writeErrors = wrs.flatMap(_.writeErrors).map(we => s"${we.code} - ${we.errmsg}").mkString("\n")
+        logger.error(s"Received ${wrs.count(_.writeErrors.nonEmpty)} write errors during journal auto-upgrade:\n$writeErrors")
       case Success(wrs) =>
         val successCount = wrs.foldLeft(0)((sum, wr) => sum + wr.n)
         logger.info(s"Successfully upgraded $successCount records")
@@ -218,14 +213,24 @@ class RxMongoDriver(system: ActorSystem, config: Config, driverProvider: RxMongo
 
   private[mongodb] def getCollections(collectionName: String)(implicit ec: ExecutionContext): Enumerator[BSONCollection] = {
     val fut = for {
-      database <- db
-      names <- database.collectionNames
-      list <- Future.sequence(names.filter(_.startsWith(collectionName)).map(collection))
+      database  <- db
+      names     <- database.collectionNames
+      list      <- Future.sequence(names.filter(_.startsWith(collectionName)).map(collection))
     } yield Enumerator(list: _*)    
     Enumerator.flatten(fut)
   }
 
+  private[mongodb] def getCollectionsAsFuture(collectionName: String)(implicit ec: ExecutionContext): Future[List[BSONCollection]] = {
+    for {
+      database  <- db
+      names     <- database.collectionNames
+      list      <- Future.sequence(names.filter(_.startsWith(collectionName)).map(collection))
+    } yield list
+  }
+
   private[mongodb] def getJournalCollections()(implicit ec: ExecutionContext) = getCollections(journalCollectionName)
+
+  private[mongodb] def journalCollectionsAsFuture(implicit ec: ExecutionContext) = getCollectionsAsFuture(journalCollectionName)
   
   private[mongodb] def getSnapshotCollections()(implicit ec: ExecutionContext) = getCollections(snapsCollectionName)
   
@@ -249,13 +254,13 @@ class RxMongoPersistenceExtension(actorSystem: ActorSystem) extends MongoPersist
     override lazy val snapshotter = new RxMongoSnapshotter(driver) with MongoPersistenceSnapshotFailFast {
       override private[mongodb] val breaker = driver.breaker
     }
-    override lazy val readJournal = new RxMongoReadJournaller(driver)
+    override lazy val readJournal = new RxMongoReadJournaller(driver, ActorMaterializer()(actorSystem))
   }
 
 }
 
 object RxMongoDriverSettings {
-  def apply(systemSettings: ActorSystem.Settings) = {
+  def apply(systemSettings: ActorSystem.Settings): RxMongoDriverSettings = {
     val fullName = s"${getClass.getPackage.getName}.rxmongo"
     val systemConfig = systemSettings.config
     systemConfig.checkValid(ConfigFactory.defaultReference(), fullName)
@@ -268,13 +273,13 @@ class RxMongoDriverSettings(val config: Config) {
   config.checkValid(config, "failover")
 
   private val failover = config.getConfig("failover")
-  def InitialDelay = failover.getFiniteDuration("initialDelay")
-  def Retries = failover.getInt("retries")
-  def Growth = failover.getString("growth")
-  def ConstantGrowth = Growth == "con"
-  def LinearGrowth = Growth == "lin"
-  def ExponentialGrowth = Growth == "exp"
-  def Factor = failover.getDouble("factor")
+  def InitialDelay: FiniteDuration = failover.getFiniteDuration("initialDelay")
+  def Retries: Int = failover.getInt("retries")
+  def Growth: String = failover.getString("growth")
+  def ConstantGrowth: Boolean = Growth == "con"
+  def LinearGrowth: Boolean = Growth == "lin"
+  def ExponentialGrowth: Boolean = Growth == "exp"
+  def Factor: Double = failover.getDouble("factor")
 
   def GrowthFunction: Int => Double = Growth match {
     case "con" => (i: Int) => Factor

--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoReadJournaller.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoReadJournaller.scala
@@ -6,246 +6,116 @@
 
 package akka.contrib.persistence.mongodb
 
+import akka.NotUsed
 import akka.actor._
 import akka.contrib.persistence.mongodb.JournallingFieldNames._
-import akka.stream.actor.ActorPublisher
-import akka.{ Done => ADone }
+import akka.contrib.persistence.mongodb.RxMongoSerializers._
+import akka.stream.Materializer
+import akka.stream.scaladsl.{Sink, Source}
 import play.api.libs.iteratee._
+import reactivemongo.akkastream.cursorProducer
 import reactivemongo.api.QueryOpts
-import reactivemongo.api.collections.bson.BSONCollection
 import reactivemongo.bson._
 
-import scala.concurrent.{ ExecutionContext, Future }
-
-import scala.util.Success
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Random
 
-
-trait IterateeActorPublisher[T] extends ActorPublisher[T] with ActorLogging {
-
-  import akka.pattern.pipe
-  import akka.stream.actor.ActorPublisherMessage._
-  import context.dispatcher
-
-  def initial: Enumerator[T]
-
-  override def preStart() = {
-    context.become(awaiting(initial andThen Enumerator.eof[T]))
-  }
-
-  override def receive: Receive = Actor.emptyBehavior
-
-  private case class Next(enumerator: Enumerator[T], iteratee: Iteratee[T, Unit])
-
-  private def respondToDemand(enumerator: Enumerator[T], iter: Iteratee[T, Unit]) = {
-    Concurrent.runPartial(enumerator, iter).map { case (_, e) => Next(e, iter) }.pipeTo(self)
-  }
-
-  private class DoneIteratee extends Iteratee[T, Unit] {
-    override def fold[B](folder: (Step[T, Unit]) => Future[B])(implicit ec: ExecutionContext): Future[B] = {
-      folder(Step.Done((), Input.Empty))
-    }
-  }
-
-  private class CursorIteratee extends Iteratee[T, Unit] {
-    override def fold[B](folder: (Step[T, Unit]) => Future[B])(implicit ec: ExecutionContext): Future[B] = {
-      folder(Step.Cont({
-        case Input.El(elem) =>
-          onNext(elem)
-          if (totalDemand > 0L) this
-          else new DoneIteratee
-        case Input.EOF =>
-          onComplete()
-          cleanup().pipeTo(self)
-          new DoneIteratee
-        case Input.Empty =>
-          if (totalDemand > 0L) this
-          else new DoneIteratee
-      }))
-    }
-  }
-
-  def cleanup(): Future[ADone] = Future.successful(ADone)
-
-  def defaults: Receive = {
-    case _: Cancel | SubscriptionTimeoutExceeded =>
-      log.warning("Cancelling stream")
-      onCompleteThenStop()
-      cleanup().pipeTo(self)
-      ()
-    case Status.Failure(t) =>
-      log.error(t, "Failure occurred while streaming")
-      onErrorThenStop(t)
-      cleanup().pipeTo(self)
-      ()
-    case ADone =>
-      context.stop(self)
-  }
-
-  def awaiting(enumerator: Enumerator[T]): Receive = defaults orElse handleNext("Awaiting") orElse {
-    case Request(_) =>
-      log.debug(s"Awaiting: Request received, demand = $totalDemand")
-      respondToDemand(enumerator, new CursorIteratee)
-      context.become(streaming(enumerator))
-  }
-
-  def streaming(enumerator: Enumerator[T]): Receive = defaults orElse handleNext("Streaming")
-
-  private def handleNext(header: String): Receive = {
-    case Next(enm, it) =>
-      log.debug("Next received")
-      if (totalDemand > 0) {
-        log.debug(s"$header: requesting more, demand = $totalDemand")
-        respondToDemand(enm, it)
-        context.become(streaming(enm))
-      } else {
-        log.debug(s"$header: nothing to do, no demand")
-        context.become(awaiting(enm))
-      }
-  }
-
-}
-
 object CurrentAllEvents {
-  def props(driver: RxMongoDriver) = Props(new CurrentAllEvents(driver))
-}
+  def source(driver: RxMongoDriver)(implicit m: Materializer): Source[Event, NotUsed] = {
+    implicit val ec = driver.querySideDispatcher
 
-class CurrentAllEvents(val driver: RxMongoDriver) extends IterateeActorPublisher[Event] {
-  import JournallingFieldNames._
-  import RxMongoSerializers._
-  import context.dispatcher
-
-  private val flatten: Enumeratee[BSONDocument, Event] = Enumeratee.mapFlatten[BSONDocument] { doc =>
-    Enumerator(
-      doc.as[BSONArray](EVENTS).values.collect {
-        case d: BSONDocument => driver.deserializeJournal(d)
-      }: _*)
-  }
-
-  private val flattenCollection: Enumeratee[BSONCollection, BSONDocument] = Enumeratee.mapFlatten[BSONCollection] { journal =>
-    journal.find(BSONDocument())
-      .projection(BSONDocument(EVENTS -> 1))
-      .cursor[BSONDocument]()
-      .enumerate()
-  }
-
-  override def initial: Enumerator[Event] = {
-
-    driver.getJournalCollections()
-      .through(flattenCollection)
-      .through(flatten)
+    Source.fromFuture(driver.journalCollectionsAsFuture)
+      .flatMapConcat(_.map { c =>
+        c.find(BSONDocument())
+          .projection(BSONDocument(EVENTS -> 1))
+          .cursor[BSONDocument]()
+          .documentSource()
+          .map { doc =>
+            doc.getAs[BSONArray](EVENTS)
+              .map(_.elements
+                .map(_.value)
+                .collect{ case d:BSONDocument => driver.deserializeJournal(d) })
+              .getOrElse(Nil)
+          }.mapConcat(identity)
+      }.reduceLeft(_ concat _))
   }
 }
 
 object CurrentAllPersistenceIds {
-  def props(driver: RxMongoDriver) = Props(new CurrentAllPersistenceIds(driver))
-}
+  def source(driver: RxMongoDriver)(implicit m: Materializer): Source[String, NotUsed] = {
+    implicit val ec = driver.querySideDispatcher
+    val temporaryCollectionName: String = s"persistenceids-${System.currentTimeMillis()}-${Random.nextInt(1000)}"
 
-class CurrentAllPersistenceIds(val driver: RxMongoDriver) extends IterateeActorPublisher[String] {
-  import JournallingFieldNames._
-  import context.dispatcher
-  import reactivemongo.bson._
-
-    val temporaryCollectionName = {
-    val name = s"persistenceids-${System.currentTimeMillis()}-${Random.nextInt(1000)}"
-    name
-  }
-  def temporaryCollection = driver.collection(temporaryCollectionName)
-
-  override def postStop() = {
-    driver.db.flatMap(_.collectionNames).andThen {
-      case Success(names) if names.contains(temporaryCollectionName) =>
-        cleanup()
-    }
-    ()
-  }
-
-  override def cleanup() = {
-    for {
-      tc <- temporaryCollection
-      dropped  <- tc.drop(failIfNotFound = false)
-    } yield {
-      ADone
-    }
-  }
-
-  private val flattened = Enumeratee.mapConcat[BSONDocument](_.getAs[String]("_id").toSeq)
-
-  private val flattenCollection: Enumeratee[BSONCollection, BSONDocument] = Enumeratee.mapFlatten[BSONCollection] { journal =>
-    import journal.BatchCommands.AggregationFramework.{ Group, Out, Project }
-
-    val enumerator = for {
-      _ <- journal.aggregate(Project(BSONDocument(PROCESSOR_ID -> 1)),
-        List(
-          Group(BSONString(s"$$$PROCESSOR_ID"))(),
-          Out(temporaryCollectionName)))
-      tc <- temporaryCollection
-    } yield tc.find(BSONDocument())
-            .cursor[BSONDocument]()
-            .enumerate()
-
-    Enumerator.flatten(enumerator)
-  }
-
-  override def initial: Enumerator[String] = {
-    driver.getJournalCollections()
-      .through(flattenCollection)
-      .through(flattened)
+    Source.fromFuture(for {
+        collections <- driver.journalCollectionsAsFuture
+        tmpNames    <- Future.sequence(collections.zipWithIndex.map { case (c,idx) =>
+                          import c.BatchCommands.AggregationFramework.{Group, Out, Project}
+                          val nameWithIndex = s"$temporaryCollectionName-$idx"
+                          c.aggregate(
+                            Project(BSONDocument(PROCESSOR_ID -> 1)),
+                            Group(BSONString(s"$$$PROCESSOR_ID"))() ::
+                            Out(nameWithIndex) ::
+                            Nil
+                          ).map(_ => nameWithIndex)
+                        })
+        tmps         <- Future.sequence(tmpNames.map(driver.collection))
+      } yield tmps )
+      .flatMapConcat(cols => cols.map(_.find(BSONDocument()).cursor[BSONDocument]().documentSource()).reduce(_ ++ _))
+      .mapConcat(_.getAs[String]("_id").toList)
+      .alsoTo(Sink.onComplete{ _ =>
+        driver
+          .getCollectionsAsFuture(temporaryCollectionName)
+          .foreach(cols =>
+            cols.foreach(_.drop(failIfNotFound = false))
+          )
+      })
   }
 }
 
 object CurrentEventsByPersistenceId {
-  def props(driver: RxMongoDriver, persistenceId: String, fromSeq: Long, toSeq: Long): Props =
-    Props(new CurrentEventsByPersistenceId(driver, persistenceId, fromSeq, toSeq))
-}
+  def source(driver: RxMongoDriver, persistenceId: String, fromSeq: Long, toSeq: Long)(implicit m: Materializer): Source[Event, NotUsed] = {
+    implicit val ec = driver.querySideDispatcher
 
-class CurrentEventsByPersistenceId(val driver: RxMongoDriver, persistenceId: String, fromSeq: Long, toSeq: Long) extends IterateeActorPublisher[Event] {
-  import JournallingFieldNames._
-  import RxMongoSerializers._
-  import context.dispatcher
-
-  private val flatten: Enumeratee[BSONDocument, Event] = Enumeratee.mapFlatten[BSONDocument] { doc =>
-    Enumerator(
-      doc.as[BSONArray](EVENTS).values.collect {
-        case d: BSONDocument => driver.deserializeJournal(d)
-      }: _*)
-  }
-
-  private val filter = Enumeratee.filter[Event] { e =>
-    e.sn >= fromSeq && e.sn <= toSeq
-  }
-
-  override def initial = Enumerator.flatten {
-
-    val q = BSONDocument(
+    val query = BSONDocument(
       PROCESSOR_ID -> persistenceId,
       TO -> BSONDocument("$gte" -> fromSeq),
       FROM -> BSONDocument("$lte" -> toSeq))
 
-    driver.getJournal(persistenceId)
-      .map(_.find(q)
-        .sort(BSONDocument(TO -> 1))
-        .projection(BSONDocument(EVENTS -> 1))
-        .cursor[BSONDocument]()
-        .enumerate()
-        .through(flatten)
-        .through(filter))
+    Source.fromFuture(driver.getJournal(persistenceId))
+            .flatMapConcat(
+              _.find(query)
+                .sort(BSONDocument(TO -> 1))
+                .projection(BSONDocument(EVENTS -> 1))
+                .cursor[BSONDocument]()
+                .documentSource()
+            ).map( doc =>
+              doc.getAs[BSONArray](EVENTS)
+                .map(_.elements
+                  .map(_.value)
+                  .collect{ case d:BSONDocument => driver.deserializeJournal(d) })
+                .getOrElse(Nil)
+            ).mapConcat(identity)
   }
 }
 
-class RxMongoJournalStream(driver: RxMongoDriver) extends JournalStream[Enumerator[BSONDocument]] {
+class RxMongoJournalStream(driver: RxMongoDriver)(implicit m: Materializer) extends JournalStream[Source[Event, NotUsed]] {
   import RxMongoSerializers._
 
-  implicit val ec = driver.querySideDispatcher
+  implicit val ec: ExecutionContext = driver.querySideDispatcher
 
-  override def cursor() =
-    Enumerator.flatten(
-      driver.realtime.map(rt =>
+  override def cursor(): Source[Event,NotUsed] =
+    Source.fromFuture(driver.realtime)
+      .flatMapConcat {rt =>
         rt.find(BSONDocument.empty)
           .options(QueryOpts().tailable.awaitData)
           .cursor[BSONDocument]()
-          .enumerate()
-          ))
+          .documentSource()
+          .map ( _.getAs[BSONArray](EVENTS).map(_.elements.map(e => e.value).collect {
+              case d: BSONDocument => driver.deserializeJournal(d)
+          }).getOrElse(Nil)
+          )
+          .mapConcat(identity _)
+      }
 
   private val flatten: Enumeratee[BSONDocument, Event] = Enumeratee.mapFlatten[BSONDocument] { doc =>
     Enumerator(
@@ -254,27 +124,29 @@ class RxMongoJournalStream(driver: RxMongoDriver) extends JournalStream[Enumerat
       }: _*)
   }
 
-  override def publishEvents() = {
-    val iteratee = Iteratee.foreach[Event](driver.actorSystem.eventStream.publish)
-    cursor().through(flatten).run(iteratee)
+  override def publishEvents(): Unit = {
+    val sink = Sink.foreach[Event](driver.actorSystem.eventStream.publish)
+    cursor().runWith(sink)
     ()
   }
 }
 
-class RxMongoReadJournaller(driver: RxMongoDriver) extends MongoPersistenceReadJournallingApi {
+class RxMongoReadJournaller(driver: RxMongoDriver, m: Materializer) extends MongoPersistenceReadJournallingApi {
 
-  val journalStream = {
-    val stream = new RxMongoJournalStream(driver)
+  val journalStream: RxMongoJournalStream = {
+    val stream = new RxMongoJournalStream(driver)(m)
     stream.publishEvents()
     stream
   }
 
-  override def currentAllEvents: Props = CurrentAllEvents.props(driver)
+  override def currentAllEvents(implicit m: Materializer): Source[Event, NotUsed] =
+    CurrentAllEvents.source(driver)
 
-  override def currentPersistenceIds: Props = CurrentAllPersistenceIds.props(driver)
+  override def currentPersistenceIds(implicit m: Materializer): Source[String, NotUsed] =
+    CurrentAllPersistenceIds.source(driver)
 
-  override def currentEventsByPersistenceId(persistenceId: String, fromSeq: Long, toSeq: Long): Props =
-    CurrentEventsByPersistenceId.props(driver, persistenceId, fromSeq, toSeq)
+  override def currentEventsByPersistenceId(persistenceId: String, fromSeq: Long, toSeq: Long)(implicit m: Materializer): Source[Event, NotUsed] =
+    CurrentEventsByPersistenceId.source(driver, persistenceId, fromSeq, toSeq)
 
   override def subscribeJournalEvents(subscriber: ActorRef): Unit = {
     driver.actorSystem.eventStream.subscribe(subscriber, classOf[Event])

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoDatabaseConfigSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoDatabaseConfigSpec.scala
@@ -30,7 +30,7 @@ class RxMongoDatabaseConfigSpec extends BaseUnitTest with ContainerMongo with Be
   override def embedDB = "admin"
 
   "Persistence store database config" should "be User-Specified-Database" in withConfig(config, "akka-contrib-mongodb-persistence-journal") { case (actorSystem, c) =>
-    val underTest = new RxMongoDriver(actorSystem, c)
+    val underTest = new RxMongoDriver(actorSystem, c, new RxMongoDriverProvider(actorSystem))
     assertResult("User-Specified-Database")(underTest.db.futureValue.name)
     ()
   }

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoJournalUpgradeSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoJournalUpgradeSpec.scala
@@ -6,4 +6,9 @@
 
 package akka.contrib.persistence.mongodb
 
-class RxMongoJournalUpgradeSpec extends JournalUpgradeSpec(classOf[RxMongoPersistenceExtension], "rxmongo", new RxMongoDriver(_,_), RxMongoConfigTest.rxMongoConfig)
+class RxMongoJournalUpgradeSpec
+  extends JournalUpgradeSpec(
+    classOf[RxMongoPersistenceExtension],
+    "rxmongo",
+    (sys,cfg) => new RxMongoDriver(sys,cfg,new RxMongoDriverProvider(sys)),
+    RxMongoConfigTest.rxMongoConfig)

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceDriverSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceDriverSpec.scala
@@ -62,7 +62,7 @@ class RxMongoPersistenceDriverShutdownSpec extends BaseUnitTest with ContainerMo
 @RunWith(classOf[JUnitRunner])
 class RxMongoPersistenceDriverAuthSpec extends BaseUnitTest with ContainerMongo with BeforeAndAfterAll {
 
-  val authMode = if( "3.0" :: "3.2" :: Nil exists envMongoVersion.contains) "?authMode=scram-sha1" else ""
+  val authMode = if( "3.0" :: "3.2" :: "3.4" :: Nil exists envMongoVersion.contains) "?authMode=scram-sha1" else "?authMode=mongocr"
 
   val authConfig = ConfigFactory.parseString(
     s"""

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceSpec.scala
@@ -9,10 +9,10 @@ package akka.contrib.persistence.mongodb
 import akka.pattern.CircuitBreaker
 import akka.testkit.TestKit
 import akka.testkit._
-import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
+import com.typesafe.config.ConfigFactory
 import reactivemongo.api.collections.bson.BSONCollection
 import play.api.libs.iteratee._
-import reactivemongo.api.FailoverStrategy
+import reactivemongo.api.{DefaultDB, FailoverStrategy}
 
 import scala.concurrent._
 import scala.concurrent.duration._
@@ -32,22 +32,20 @@ trait RxMongoPersistenceSpec extends MongoPersistenceSpec[RxMongoDriver, BSONCol
   }
 
   val driver = new SpecDriver
-  lazy val specDb = driver.db
+  lazy val specDb: Future[DefaultDB] = driver.db
 
   val extendedDriver = new ExtendedSpecDriver
-  lazy val extendedSpecDb = extendedDriver.db
+  lazy val extendedSpecDb: Future[DefaultDB] = extendedDriver.db
 
   def withCollection(name: String)(testCode: BSONCollection => Any): Unit = {
     for {
       db <- specDb
       c = db.apply[BSONCollection](name, FailoverStrategy.default)
-    } yield {
+    } {
       try {
         testCode(c)
-        ()
       } finally {
         Await.ready(c.drop(failIfNotFound = false), 3.seconds.dilated)
-        ()
       }
     }
   }
@@ -56,13 +54,11 @@ trait RxMongoPersistenceSpec extends MongoPersistenceSpec[RxMongoDriver, BSONCol
     for {
       db <- extendedSpecDb
       c = db[BSONCollection](name)
-    } yield {
+    } {
       try {
         testCode(c)
-        ()
       } finally {
         Await.ready(c.drop(failIfNotFound = false), 3.seconds.dilated)
-        ()
       }
     }
   }
@@ -88,27 +84,27 @@ trait RxMongoPersistenceSpec extends MongoPersistenceSpec[RxMongoDriver, BSONCol
     }
   }
 
-  def withEmptyJournal(testCode: BSONCollection => Any) = withCollection(driver.journalCollectionName) { coll =>
+  def withEmptyJournal(testCode: BSONCollection => Any): Unit = withCollection(driver.journalCollectionName) { coll =>
     Await.result(coll.drop(failIfNotFound = false), 3.seconds.dilated)
     testCode(coll)
   }
 
-  def withJournal(testCode: BSONCollection => Any) =
+  def withJournal(testCode: BSONCollection => Any): Unit =
     withCollection(driver.journalCollectionName)(testCode)
 
-  def withSuffixedJournal(pid: String)(testCode: BSONCollection => Any) =
+  def withSuffixedJournal(pid: String)(testCode: BSONCollection => Any): Unit =
     withSuffixedCollection(extendedDriver.getJournalCollectionName(pid))(testCode)
 
-  def withAutoSuffixedJournal(testCode: RxMongoDriver => Any) =
+  def withAutoSuffixedJournal(testCode: RxMongoDriver => Any): Unit =
     withJournalCollections(testCode)
 
-  def withSnapshot(testCode: BSONCollection => Any) =
+  def withSnapshot(testCode: BSONCollection => Any): Unit =
     withCollection(driver.snapsCollectionName)(testCode)
 
-  def withSuffixedSnapshot(pid: String)(testCode: BSONCollection => Any) =
+  def withSuffixedSnapshot(pid: String)(testCode: BSONCollection => Any): Unit =
     withSuffixedCollection(extendedDriver.getSnapsCollectionName(pid))(testCode)
 
-  def withAutoSuffixedSnapshot(testCode: RxMongoDriver => Any) =
+  def withAutoSuffixedSnapshot(testCode: RxMongoDriver => Any): Unit =
     withSnapshotCollections(testCode)
 
 }


### PR DESCRIPTION
* RxM supports streams internally - use those for read journal
* Other RxM changes to support transition from 0.11.x -> 0.12.x

* Some style cleanup, e.g. more explicit return types
* Update akka to latest
* Prepare for a 1.4.0 release

Fixes #128 