### PR TITLE
Fix high cpu usage when "realtime" is disabled.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,36 +1,40 @@
-val releaseV = "2.0.7"
+val releaseV = "2.0.7.1"
 
 val scalaV = "2.11.8"
 
 scalaVersion := scalaV
 
-crossScalaVersions := Seq("2.11.8", "2.12.2")
+crossScalaVersions := Seq("2.11.8", "2.12.4")
 
-val AkkaV = "2.5.1"
+val AkkaV = "2.5.11"
 
-def commonDeps(sv:String) = Seq(
-  ("com.typesafe.akka"  %% "akka-persistence" % AkkaV % "provided")
+def commonDeps(sv: String) = Seq(
+  ("com.typesafe.akka" %% "akka-persistence" % AkkaV % "provided")
     .exclude("org.iq80.leveldb", "leveldb")
     .exclude("org.fusesource.leveldbjni", "leveldbjni-all"),
-  (sv match {
-    case "2.11" => "nl.grons"           %% "metrics-scala" % "3.5.5_a2.3"
-    case "2.12" => "nl.grons"           %% "metrics-scala" % "3.5.5_a2.4"
-  })
-    .exclude("com.typesafe.akka", "akka-actor_2.11")
-    .exclude("com.typesafe.akka", "akka-actor_2.12"),
-  "com.typesafe.akka"         %% "akka-persistence-query"   % AkkaV     % "provided",
-  "org.mongodb"               % "mongodb-driver"            % "3.6.3"   % "test",
-  "org.slf4j"                 % "slf4j-api"                 % "1.7.22"  % "test",
-  "org.apache.logging.log4j"  % "log4j-api"                 % "2.5"     % "test",
-  "org.apache.logging.log4j"  % "log4j-core"                % "2.5"     % "test",
-  "org.apache.logging.log4j"  % "log4j-slf4j-impl"          % "2.5"     % "test",
-  "org.scalatest"             %% "scalatest"                % "3.0.1"   % "test",
-  "junit"                     % "junit"                     % "4.11"    % "test",
-  "org.mockito"               % "mockito-all"               % "1.9.5"   % "test",
-  "com.typesafe.akka"         %% "akka-slf4j"               % AkkaV     % "test",
-  "com.typesafe.akka"         %% "akka-testkit"             % AkkaV     % "test",
-  "com.typesafe.akka"         %% "akka-persistence-tck"     % AkkaV     % "test",
-  "com.typesafe.akka"         %% "akka-cluster-sharding"    % AkkaV     % "test"
+  "com.typesafe.akka" %% "akka-persistence-query" % AkkaV % "provided",
+
+  //  (sv match {
+  //    case "2.11" => "nl.grons" %% "metrics-scala" % "3.5.5_a2.3"
+  //    case "2.12" => "nl.grons" %% "metrics-scala" % "3.5.5_a2.4"
+  //  })
+  //    .exclude("com.typesafe.akka", "akka-actor_2.11")
+  //    .exclude("com.typesafe.akka", "akka-actor_2.12")
+  //    .exclude("org.slf4j", "slf4j-api"),
+
+  "org.slf4j" % "slf4j-api" % "1.7.25",
+
+  "org.mongodb" % "mongodb-driver" % "3.6.3" % "test",
+  "org.apache.logging.log4j" % "log4j-api" % "2.5" % "test",
+  "org.apache.logging.log4j" % "log4j-core" % "2.5" % "test",
+  "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.5" % "test",
+  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
+  "junit" % "junit" % "4.11" % "test",
+  "org.mockito" % "mockito-all" % "1.9.5" % "test",
+  "com.typesafe.akka" %% "akka-slf4j" % AkkaV % "test",
+  "com.typesafe.akka" %% "akka-testkit" % AkkaV % "test",
+  "com.typesafe.akka" %% "akka-persistence-tck" % AkkaV % "test",
+  "com.typesafe.akka" %% "akka-cluster-sharding" % AkkaV % "test"
 )
 
 val commonSettings = Seq(
@@ -41,7 +45,7 @@ val commonSettings = Seq(
   scalacOptions ++= Seq(
     "-unchecked",
     "-deprecation",
-    "-encoding", "UTF-8",       // yes, this is 2 args
+    "-encoding", "UTF-8", // yes, this is 2 args
     "-feature",
     "-language:existentials",
     "-language:higherKinds",
@@ -49,11 +53,11 @@ val commonSettings = Seq(
     // "-Xfatal-warnings",      Deprecations keep from enabling this
     "-Xlint",
     "-Yno-adapted-args",
-    "-Ywarn-dead-code",        // N.B. doesn't work well with the ??? hole
+    "-Ywarn-dead-code", // N.B. doesn't work well with the ??? hole
     "-Ywarn-numeric-widen",
     "-Ywarn-value-discard",
     "-Xfuture",
-    "-Ywarn-unused-import",     // 2.11 only
+    "-Ywarn-unused-import", // 2.11 only
     "-target:jvm-1.8"
   ),
   javacOptions ++= Seq(
@@ -67,41 +71,58 @@ val commonSettings = Seq(
     "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
   ),
   parallelExecution in Test := false,
-  testOptions in Test += Tests.Argument("-oDS")
+  testOptions in Test += Tests.Argument("-oDS"),
+  assembleArtifact in assemblyPackageScala := false,
+  test in assembly := {},
+  assemblyJarName in assembly := s"${name.value}_${scalaBinaryVersion.value}-assembly-${version.value}.jar",
+  assemblyExcludedJars in assembly := {
+    val cp = (fullClasspath in assembly).value
+    cp filter {
+      _.data.getName.startsWith("slf4j")
+    }
+  }
 )
 
 lazy val `akka-persistence-mongo-common` = (project in file("common"))
-  .settings(commonSettings:_*)
+  .settings(commonSettings: _*)
+  .settings(
+    libraryDependencies += (scalaBinaryVersion.value match {
+      case "2.11" => "nl.grons" %% "metrics-scala" % "3.5.5_a2.3"
+      case "2.12" => "nl.grons" %% "metrics-scala" % "3.5.5_a2.4"
+    })
+      .exclude("com.typesafe.akka", "akka-actor_2.11")
+      .exclude("com.typesafe.akka", "akka-actor_2.12")
+      .exclude("org.slf4j", "slf4j-api")
+  )
 
 lazy val `akka-persistence-mongo-casbah` = (project in file("casbah"))
   .dependsOn(`akka-persistence-mongo-common` % "test->test;compile->compile")
-  .settings(commonSettings:_*)
+  .settings(commonSettings: _*)
   .settings(
     libraryDependencies ++= Seq(
       "org.mongodb" %% "casbah" % "3.1.1" % "provided",
-      "org.mongodb" %  "mongo-java-driver" % "3.6.3" % "test"
+      "org.mongodb" % "mongo-java-driver" % "3.6.3" % "test"
     )
   )
 
 lazy val `akka-persistence-mongo-rxmongo` = (project in file("rxmongo"))
   .dependsOn(`akka-persistence-mongo-common` % "test->test;compile->compile")
-  .settings(commonSettings:_*)
+  .settings(commonSettings: _*)
   .settings(
     libraryDependencies ++= Seq(
-      ("org.reactivemongo" %% "reactivemongo" % "0.12.3" % "provided")
-        .exclude("com.typesafe.akka","akka-actor_2.11")
-        .exclude("com.typesafe.akka","akka-actor_2.12"),
-      ("org.reactivemongo" %% "reactivemongo-akkastream" % "0.12.3" % "provided")
-        .exclude("com.typesafe.akka","akka-actor_2.11")
-        .exclude("com.typesafe.akka","akka-actor_2.12")
-    ),
-    crossScalaVersions := Seq("2.11.8"),
-    scalaVersion := "2.11.8"
+      ("org.reactivemongo" %% "reactivemongo" % "0.12.6" % "provided")
+        .exclude("com.typesafe.akka", "akka-actor_2.11")
+        .exclude("com.typesafe.akka", "akka-actor_2.12"),
+
+      ("org.reactivemongo" %% "reactivemongo-akkastream" % "0.12.6" % "provided")
+        .exclude("com.typesafe.akka", "akka-actor_2.11")
+        .exclude("com.typesafe.akka", "akka-actor_2.12")
+    )
   )
 
 lazy val `akka-persistence-mongo-tools` = (project in file("tools"))
   .dependsOn(`akka-persistence-mongo-casbah` % "test->test;compile->compile")
-  .settings(commonSettings:_*)
+  .settings(commonSettings: _*)
   .settings(
     libraryDependencies ++= Seq(
       "org.mongodb" %% "casbah" % "3.1.1" % "provided"
@@ -110,7 +131,7 @@ lazy val `akka-persistence-mongo-tools` = (project in file("tools"))
 
 lazy val `akka-persistence-mongo` = (project in file("."))
   .aggregate(`akka-persistence-mongo-common`, `akka-persistence-mongo-casbah`, `akka-persistence-mongo-rxmongo`, `akka-persistence-mongo-tools`)
-  .settings(commonSettings:_*)
+  .settings(commonSettings: _*)
   .settings(
     packagedArtifacts in file(".") := Map.empty,
     publishTo := Some(Resolver.file("file", new File("target/unusedrepo"))))

--- a/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistence.scala
+++ b/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistence.scala
@@ -35,10 +35,10 @@ object MongoPersistenceDriver {
   case object ReplicaAcknowledged extends WriteSafety
 
   implicit def string2WriteSafety(fromConfig: String): WriteSafety = fromConfig.toLowerCase match {
-    case "errorsignored"       => throw new IllegalArgumentException("Errors ignored is no longer supported as a write safety option")
-    case "unacknowledged"      => Unacknowledged
-    case "acknowledged"        => Acknowledged
-    case "journaled"           => Journaled
+    case "errorsignored" => throw new IllegalArgumentException("Errors ignored is no longer supported as a write safety option")
+    case "unacknowledged" => Unacknowledged
+    case "acknowledged" => Acknowledged
+    case "journaled" => Journaled
     case "replicaacknowledged" => ReplicaAcknowledged
   }
 
@@ -59,6 +59,7 @@ trait CanDeserializeJournal[D] {
 
 trait CanSuffixCollectionNames {
   def getSuffixFromPersistenceId(persistenceId: String): String
+
   def validateMongoCharacters(input: String): String
 }
 
@@ -67,6 +68,7 @@ trait JournalFormats[D] extends CanSerializeJournal[D] with CanDeserializeJourna
 private case class IndexSettings(name: String, unique: Boolean, sparse: Boolean, fields: (String, Int)*)
 
 abstract class MongoPersistenceDriver(as: ActorSystem, config: Config) {
+
   import MongoPersistenceDriver._
 
   // Collection type
@@ -110,8 +112,8 @@ abstract class MongoPersistenceDriver(as: ActorSystem, config: Config) {
   private[mongodb] def upgradeJournalIfNeeded(persistenceId: String): Unit
 
   /**
-   * retrieve suffix from persistenceId
-   */
+    * retrieve suffix from persistenceId
+    */
   private[this] def getSuffixFromPersistenceId(persistenceId: String): String = suffixBuilderClassOption match {
     case Some(suffixBuilderClass) if !suffixBuilderClass.trim.isEmpty =>
       val builderClass = Class.forName(suffixBuilderClass)
@@ -122,8 +124,8 @@ abstract class MongoPersistenceDriver(as: ActorSystem, config: Config) {
   }
 
   /**
-   * validate characters in collection name
-   */
+    * validate characters in collection name
+    */
   private[this] def validateMongoCharacters(input: String): String = suffixBuilderClassOption match {
     case Some(suffixBuilderClass) if !suffixBuilderClass.trim.isEmpty =>
       val builderClass = Class.forName(suffixBuilderClass)
@@ -134,8 +136,8 @@ abstract class MongoPersistenceDriver(as: ActorSystem, config: Config) {
   }
 
   /**
-   * retrieve collection from persistenceId
-   */
+    * retrieve collection from persistenceId
+    */
   private[this] def getSuffixedCollection(persistenceId: String)(build: String => String): C = {
     val name = build(getSuffixFromPersistenceId(persistenceId))
     logger.debug(s"Name used to build collection is $name")
@@ -143,46 +145,46 @@ abstract class MongoPersistenceDriver(as: ActorSystem, config: Config) {
   }
 
   /**
-   * build name of a collection by appending separator and suffix to usual name in settings
-   */
+    * build name of a collection by appending separator and suffix to usual name in settings
+    */
   private[this] def appendSuffixToName(nameInSettings: String)(suffix: String): String = {
     val name =
       suffix match {
         case "" => nameInSettings
-        case _  => s"$nameInSettings$suffixSeparator${validateMongoCharacters(suffix)}"
+        case _ => s"$nameInSettings$suffixSeparator${validateMongoCharacters(suffix)}"
       }
     logger.debug(s"""Suffixed name for value "$nameInSettings" in settings and suffix "$suffix" is "$name"""")
     name
   }
 
   /**
-   * Convenient methods to retrieve journal name from persistenceId
-   */
+    * Convenient methods to retrieve journal name from persistenceId
+    */
   private[mongodb] def getJournalCollectionName(persistenceId: String): String =
     persistenceId match {
       case "" => journalCollectionName
-      case _  => appendSuffixToName(journalCollectionName)(getSuffixFromPersistenceId(persistenceId))
+      case _ => appendSuffixToName(journalCollectionName)(getSuffixFromPersistenceId(persistenceId))
     }
 
   /**
-   * Convenient methods to retrieve snapshot name from persistenceId
-   */
+    * Convenient methods to retrieve snapshot name from persistenceId
+    */
   private[mongodb] def getSnapsCollectionName(persistenceId: String): String =
     persistenceId match {
       case "" => snapsCollectionName
-      case _  => appendSuffixToName(snapsCollectionName)(getSuffixFromPersistenceId(persistenceId))
+      case _ => appendSuffixToName(snapsCollectionName)(getSuffixFromPersistenceId(persistenceId))
     }
 
   /**
-   * Convenient methods to retrieve EXISTING journal collection from persistenceId.
-   * CAUTION: this method does NOT create the journal and its indexes.
-   */
+    * Convenient methods to retrieve EXISTING journal collection from persistenceId.
+    * CAUTION: this method does NOT create the journal and its indexes.
+    */
   private[mongodb] def getJournal(persistenceId: String): C = collection(getJournalCollectionName(persistenceId))
 
   /**
-   * Convenient methods to retrieve EXISTING snapshot collection from persistenceId.
-   * CAUTION: this method does NOT create the snapshot and its indexes.
-   */
+    * Convenient methods to retrieve EXISTING snapshot collection from persistenceId.
+    * CAUTION: this method does NOT create the snapshot and its indexes.
+    */
   private[mongodb] def getSnaps(persistenceId: String): C = collection(getSnapsCollectionName(persistenceId))
 
   private[mongodb] lazy val indexes: Seq[IndexSettings] = Seq(
@@ -213,7 +215,7 @@ abstract class MongoPersistenceDriver(as: ActorSystem, config: Config) {
     })
   }
 
-  private[mongodb] def removeJournalInCache(persistenceId:String) = {
+  private[mongodb] def removeJournalInCache(persistenceId: String) = {
     val collectionName = getJournalCollectionName(persistenceId)
     journalMap.remove(collectionName)
   }
@@ -245,32 +247,53 @@ abstract class MongoPersistenceDriver(as: ActorSystem, config: Config) {
   def useSuffixedCollectionNames = suffixBuilderClassOption.isDefined
 
   def databaseName = settings.Database
+
   def snapsCollectionName = settings.SnapsCollection
+
   def snapsIndexName = settings.SnapsIndex
+
   def snapsWriteSafety: WriteSafety = settings.SnapsWriteConcern
+
   def snapsWTimeout = settings.SnapsWTimeout
+
   def snapsFsync = settings.SnapsFSync
+
   def journalCollectionName = settings.JournalCollection
+
   def journalIndexName = settings.JournalIndex
+
   def journalSeqNrIndexName = settings.JournalSeqNrIndex
+
   def journalTagIndexName = settings.JournalTagIndex
+
   def journalWriteSafety: WriteSafety = settings.JournalWriteConcern
+
   def journalWTimeout = settings.JournalWTimeout
+
   def journalFsync = settings.JournalFSync
+
   def realtimeEnablePersistence = settings.realtimeEnablePersistence
+
   def realtimeCollectionName = settings.realtimeCollectionName
+
   def realtimeCollectionSize = settings.realtimeCollectionSize
+
   def metadataCollectionName = settings.MetadataCollection
+
   def mongoUri = settings.MongoUri
+
   def useLegacySerialization = settings.UseLegacyJournalSerialization
 
   def suffixBuilderClassOption = Option(settings.SuffixBuilderClass).filter(_.trim.nonEmpty)
+
   def suffixSeparator = settings.SuffixSeparator match {
     case str if !str.isEmpty => validateMongoCharacters(settings.SuffixSeparator).substring(0, 1)
-    case _                   => "_"
+    case _ => "_"
   }
+
   def suffixDropEmpty = settings.SuffixDropEmptyCollections
 
   def deserializeJournal(dbo: D)(implicit ev: CanDeserializeJournal[D]) = ev.deserializeDocument(dbo)
+
   def serializeJournal(aw: Atom)(implicit ev: CanSerializeJournal[D]) = ev.serializeAtom(aw)
 }

--- a/common/src/test/scala/akka/contrib/persistence/mongodb/ReadJournalSpec.scala
+++ b/common/src/test/scala/akka/contrib/persistence/mongodb/ReadJournalSpec.scala
@@ -433,9 +433,9 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
       implicit val ec = as.dispatcher
 
       val done = Future.sequence(promises.map(_._1.future))
-      Await.result(done, 10.seconds.dilated)
+      Await.result(done, 20.seconds.dilated)
 
-      probe.receiveN(nrOfActors * nrOfEvents, 10.seconds.dilated) should have size (nrOfActors.toLong * nrOfEvents)
+      probe.receiveN(nrOfActors * nrOfEvents, 20.seconds.dilated) should have size (nrOfActors.toLong * nrOfEvents)
       ks.shutdown()
   }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,7 @@
-libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value
+//libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")


### PR DESCRIPTION
* Whe the property `akka.contrib.persistence.mongodb.mongo.realtime-enable-persistence` is `false` the read in this collection also is disabled.
* Filter out the "realtime" collection in the function `getAllCollectionsAsFuture`: this avoid duplicated events read when "realtime" persistence is activated.
