### PR TITLE
Two fixes

### DIFF
--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceExtension.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceExtension.scala
@@ -231,7 +231,7 @@ class RxMongoDriver(system: ActorSystem, config: Config, driverProvider: RxMongo
     for {
       database  <- db
       names     <- database.collectionNames
-      list      <- Future.sequence(names.filter(nameFilter.getOrElse(_ => true)).map(collection))
+      list      <- Future.sequence(names.filterNot(_ == realtimeCollectionName).filter(nameFilter.getOrElse(_ => true)).map(collection))
     } yield list
   }
 


### PR DESCRIPTION
Fix#1 - Filter out realtime collection name when using multiple collections.
Fix#2 - Use the configuration to enable/disable the realtime cursor.

