### PR TITLE
Filter database system collections

### DIFF
--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceExtension.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceExtension.scala
@@ -228,10 +228,14 @@ class RxMongoDriver(system: ActorSystem, config: Config, driverProvider: RxMongo
   private[mongodb] def getJournalCollections()(implicit ec: ExecutionContext) = getCollections(journalCollectionName)
 
   private[mongodb] def getAllCollectionsAsFuture(nameFilter: Option[String => Boolean])(implicit ec: ExecutionContext): Future[List[BSONCollection]] = {
+    def excluded(name: String): Boolean =
+      name == realtimeCollectionName ||
+        name.startsWith("system.")
+
     for {
       database  <- db
       names     <- database.collectionNames
-      list      <- Future.sequence(names.filterNot(_ == realtimeCollectionName).filter(nameFilter.getOrElse(_ => true)).map(collection))
+      list      <- Future.sequence(names.filterNot(excluded).filter(nameFilter.getOrElse(_ => true)).map(collection))
     } yield list
   }
 


### PR DESCRIPTION
Following the discussion on #188 , it appears `CurrentEventsByTag` is trying to concat eventual events from every collection in database. 

This aims to filter out system collections from this process to avoid permissions error when using an unprivileged user (like mongoDB default role `readWrite`)

Please let me know if this is any help, needs refinement or has unwanted side effects 

Benoit