### PR TITLE
Fix: Adding support for the latest reactivemongo version.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -88,10 +88,10 @@ lazy val `akka-persistence-mongo-rxmongo` = (project in file("rxmongo"))
   .settings(commonSettings:_*)
   .settings(
     libraryDependencies ++= Seq(
-      ("org.reactivemongo" %% "reactivemongo" % "0.12.3" % "provided")
+      ("org.reactivemongo" %% "reactivemongo" % "0.15.0" % "provided")
         .exclude("com.typesafe.akka","akka-actor_2.11")
         .exclude("com.typesafe.akka","akka-actor_2.12"),
-      ("org.reactivemongo" %% "reactivemongo-akkastream" % "0.12.3" % "provided")
+      ("org.reactivemongo" %% "reactivemongo-akkastream" % "0.15.0" % "provided")
         .exclude("com.typesafe.akka","akka-actor_2.11")
         .exclude("com.typesafe.akka","akka-actor_2.12")
     ),

--- a/test_containers.sh
+++ b/test_containers.sh
@@ -9,8 +9,8 @@ docker pull scullxbones/mongodb:$MONGODB_VERSION
 docker ps -a | grep scullxbones/mongodb | awk '{print $1}' | xargs docker rm -f
 sleep 3
 
-docker run -d -p $MONGODB_NOAUTH_PORT:27017 scullxbones/mongodb:$MONGODB_VERSION --noauth $MONGODB_OPTS
-docker run -d -p $MONGODB_AUTH_PORT:27017 scullxbones/mongodb:$MONGODB_VERSION --auth $MONGODB_OPTS
+docker run --rm --name mongo_noauth -d -p $MONGODB_NOAUTH_PORT:27017 scullxbones/mongodb:$MONGODB_VERSION --noauth $MONGODB_OPTS
+docker run --rm --name mongo_auth -d -p $MONGODB_AUTH_PORT:27017 scullxbones/mongodb:$MONGODB_VERSION --auth $MONGODB_OPTS
 
 sleep 3
-docker exec $(docker ps -a | grep -e "--auth" | awk '{print $1;}') mongo admin --eval "db.createUser({user:'admin',pwd:'password',roles:['root']});"
+docker exec mongo_auth mongo admin --eval "db.createUser({user:'admin',pwd:'password',roles:['root']});"


### PR DESCRIPTION
**Fix**: Adding support for the latest reactivemongo's version (0.15.0). This version supports SNI name, that is needed to connect to a Mongo Altas Server.

**Note**: `ensureIndex()` is deprecated and fails when the collection or database does not exists.

Regards,
Rodrigo.
