### PR TITLE
Allows to provide a custom MetricsBuilder

### DIFF
--- a/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournaller.scala
+++ b/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournaller.scala
@@ -19,7 +19,7 @@ import scala.annotation.tailrec
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
-class CasbahPersistenceJournaller(driver: CasbahMongoDriver) extends MongoPersistenceJournallingApi {
+class CasbahPersistenceJournaller(val driver: CasbahMongoDriver) extends MongoPersistenceJournallingApi {
 
   import driver.CasbahSerializers._
 

--- a/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournallerSpec.scala
+++ b/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournallerSpec.scala
@@ -677,7 +677,7 @@ class CasbahPersistenceJournallerSpec extends TestKit(ActorSystem("unit-test")) 
         val buf = mutable.Buffer[PersistentRepr]()
         underTest.replayJournal("unit-test", 2, 3, 10)(replay(buf)).value.get.get
 
-        val registry = MongoPersistenceDriver.registry
+        val registry = DropwizardMetrics.metricRegistry
         registry.getTimers() should have size 4
         registry.getTimers().keySet() should contain("akka-persistence-mongo.journal.casbah.read.max-seq.timer")
         registry.getTimers().get("akka-persistence-mongo.journal.casbah.read.max-seq.timer").getCount should be > 0L
@@ -698,7 +698,7 @@ class CasbahPersistenceJournallerSpec extends TestKit(ActorSystem("unit-test")) 
         val buf = mutable.Buffer[PersistentRepr]()
         underExtendedTest.replayJournal("unit-test", 2, 3, 10)(replay(buf)).value.get.get
 
-        val registry = MongoPersistenceDriver.registry
+        val registry = DropwizardMetrics.metricRegistry
         registry.getTimers() should have size 4
         registry.getTimers().keySet() should contain("akka-persistence-mongo.journal.casbah.read.max-seq.timer")
         registry.getTimers().get("akka-persistence-mongo.journal.casbah.read.max-seq.timer").getCount should be > 0L

--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -50,6 +50,11 @@ akka {
             # override its method, and provide its complete path in the 'class' field below.
             class = ""
           }
+
+          metrics-builder {
+            class = ""
+          }
+
           # Set to true to drop suffixed collections when empty
           suffix-drop-empty-collections = false
           

--- a/common/src/main/scala/akka/contrib/persistence/mongodb/MongoMetrics.scala
+++ b/common/src/main/scala/akka/contrib/persistence/mongodb/MongoMetrics.scala
@@ -1,0 +1,140 @@
+package akka.contrib.persistence.mongodb
+
+import com.codahale.metrics.Timer.Context
+import com.codahale.metrics.{MetricRegistry, SharedMetricRegistries}
+import nl.grons.metrics.scala._
+
+/**
+  * Builds timers and histograms to record metrics.
+  * This class uses either the [[MetricsBuilder]] specified by [[MongoSettings.MongoMetricsBuilderClass]] or if none
+  * is specified [[DropwizardMetrics]] will be used.
+  */
+trait MongoMetrics extends MetricsBuilder with BaseBuilder {
+
+  def driver: MongoPersistenceDriver
+
+  /**
+    * Builds a timer with the given name appended to [[BaseBuilder.metricBaseName]]
+    *
+    * @param name The name of the timer. It will get appended to [[BaseBuilder.metricBaseName]]
+    * @return the timer.
+    */
+  override def timer(name: String): MongoTimer = metrics.timer(metricBaseName.append(name).name)
+
+  /**
+    * Builds a histogram with the given name appended to [[BaseBuilder.metricBaseName]]
+    *
+    * @param name The name of the histogram. It will get appended to [[BaseBuilder.metricBaseName]]
+    * @return the histogram.
+    */
+  override def histogram(name: String): MongoHistogram = metrics.histogram(metricBaseName.append(name).name)
+
+  private[this] lazy val metrics: MetricsBuilder = {
+    val mongoMetricsBuilderClass: String = driver.settings.MongoMetricsBuilderClass.trim
+    if (mongoMetricsBuilderClass.nonEmpty) {
+      val builderClass = Class.forName(mongoMetricsBuilderClass)
+      val builderCons = builderClass.getConstructor()
+      builderCons.newInstance().asInstanceOf[MetricsBuilder]
+    } else {
+      DropwizardMetrics
+    }
+  }
+}
+
+trait MongoTimer {
+  /**
+    * Starts a timer.
+    *
+    * @return the started timer.
+    */
+  def start(): StartedMongoTimer
+}
+
+trait StartedMongoTimer {
+  /**
+    * Stops the timer.
+    *
+    * @return the measured time in nano seconds.
+    */
+  def stop(): Long
+}
+
+trait MongoHistogram {
+
+  /**
+    * Records the specified value in the histogram.
+    *
+    * @param value The value to record.
+    * @return This histogram.
+    */
+  def record(value: Int): Unit
+}
+
+trait MetricsBuilder {
+
+  /**
+    * Builds a timer with the given name.
+    *
+    * @param name The name of the timer.
+    * @return the timer.
+    */
+  def timer(name: String): MongoTimer
+
+  /**
+    * Builds a histogram with the given name.
+    *
+    * @param name The name of the histogram.
+    * @return the histogram.
+    */
+  def histogram(name: String): MongoHistogram
+}
+
+private class DropwizardTimer(dropwizardTimer: Timer) extends MongoTimer {
+
+  /**
+    * Starts a timer.
+    *
+    * @return the started timer.
+    */
+  override def start(): StartedMongoTimer = new StartedDropwizardTimer(dropwizardTimer.timerContext())
+}
+
+private class StartedDropwizardTimer(timerContext: Context) extends StartedMongoTimer {
+  /**
+    * Stops the timer.
+    *
+    * @return the measured time in nano seconds.
+    */
+  override def stop(): Long = timerContext.stop()
+}
+
+private class DropwizardHistogram(dropwizardHistogram: Histogram) extends MongoHistogram {
+
+  /**
+    * Records the specified value in the histogram.
+    *
+    * @param value The value to record.
+    * @return This histogram.
+    */
+  override def record(value: Int): Unit = {
+    dropwizardHistogram.+=(value)
+  }
+}
+
+private[mongodb] object DropwizardMetrics extends MetricsBuilder with InstrumentedBuilder {
+
+  override lazy val metricBaseName: MetricName = MetricName("")
+  override val metricRegistry: MetricRegistry = SharedMetricRegistries.getOrCreate("mongodb")
+
+  private def timerName(metric: String) = MetricName(metric, "timer").name
+
+  private def histName(metric: String) = MetricName(metric, "histo").name
+
+  override def timer(name: String): MongoTimer = {
+    new DropwizardTimer(metrics.timer(timerName(name)))
+  }
+
+  override def histogram(name: String): MongoHistogram = {
+    new DropwizardHistogram(metrics.histogram(histName(name)))
+  }
+}

--- a/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistence.scala
+++ b/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistence.scala
@@ -12,9 +12,7 @@ package akka.contrib.persistence.mongodb
 import akka.actor.ActorSystem
 import akka.contrib.persistence.mongodb.JournallingFieldNames._
 import akka.contrib.persistence.mongodb.SnapshottingFieldNames._
-import com.codahale.metrics.{MetricRegistry, SharedMetricRegistries}
 import com.typesafe.config.Config
-import nl.grons.metrics.scala.InstrumentedBuilder
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.concurrent.TrieMap
@@ -42,12 +40,6 @@ object MongoPersistenceDriver {
     case "journaled"           => Journaled
     case "replicaacknowledged" => ReplicaAcknowledged
   }
-
-  private[mongodb] val registry = SharedMetricRegistries.getOrCreate("mongodb")
-}
-
-trait Instrumented extends InstrumentedBuilder {
-  override val metricRegistry: MetricRegistry = MongoPersistenceDriver.registry
 }
 
 trait CanSerializeJournal[D] {

--- a/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistenceExtension.scala
+++ b/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistenceExtension.scala
@@ -49,7 +49,7 @@ trait ConfiguredExtension {
   def journaler: MongoPersistenceJournallingApi
   def snapshotter: MongoPersistenceSnapshottingApi
   def readJournal: MongoPersistenceReadJournallingApi
-  def registry: MetricRegistry = MongoPersistenceDriver.registry
+  def registry: MetricRegistry = DropwizardMetrics.metricRegistry
 }
 
 object MongoSettings {
@@ -112,5 +112,6 @@ class MongoSettings(val config: Config) {
   val SuffixBuilderClass: String = config.getString("suffix-builder.class")
   val SuffixSeparator: String = config.getString("suffix-builder.separator")
   val SuffixDropEmptyCollections: Boolean = config.getBoolean("suffix-drop-empty-collections")
-  
+
+  val MongoMetricsBuilderClass: String = config.getString("metrics-builder.class")
 }

--- a/docs/akka25.md
+++ b/docs/akka25.md
@@ -243,7 +243,7 @@ This will fully delegate serialization to `akka-serialization` by directly persi
 <a name="metrics"/>
 ##### Metrics (optional functionality)
 
-Depends on the excellent [Metrics-Scala library](https://github.com/erikvanoosten/metrics-scala) which in turn stands on the shoulders of codahale's excellent [Metrics library](https://github.com/dropwizard/metrics).
+By default metrics depends on the excellent [Metrics-Scala library](https://github.com/erikvanoosten/metrics-scala) which in turn stands on the shoulders of codahale's excellent [Metrics library](https://github.com/dropwizard/metrics).
 
 For this implementation, no assumptions are made about how the results are reported.  Unfortunately this means you need to inject your own reporters.  This will require you to refer to the extension in your own code, e.g.:
 
@@ -269,6 +269,15 @@ Timers:
 
 Histograms:
  - Batch sizes used for appends
+
+##### Use another Metrics Library
+If you don't want to use the default metrics library, you can also provide your own implementation of
+`akka.contrib.persistence.mongodb.MetricsBuilder` which will then be used to build your implementation of
+`akka.contrib.persistence.mongodb.MongoTimer` and `akka.contrib.persistence.mongodb.MongoHistogram`.
+
+To make akka-persistence-mongo use your `akka.contrib.persistence.mongodb.MetricsBuilder` implementation you need to
+specify the property: `akka.contrib.persistence.mongodb.mongo.metrics-builder.class` with the full qualified class name
+of your implementation of `akka.contrib.persistence.mongodb.MetricsBuilder`.
 
 #### Future plans?
  - Adding metrics to snapshotter

--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoJournaller.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoJournaller.scala
@@ -24,7 +24,7 @@ import scala.concurrent._
 import scala.util.control.NoStackTrace
 import scala.util.{Failure, Success, Try}
 
-class RxMongoJournaller(driver: RxMongoDriver) extends MongoPersistenceJournallingApi {
+class RxMongoJournaller(val driver: RxMongoDriver) extends MongoPersistenceJournallingApi {
 
   import JournallingFieldNames._
   import driver.RxMongoSerializers._

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceJournaller.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceJournaller.scala
@@ -20,7 +20,7 @@ import JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
-class ScalaDriverPersistenceJournaller(driver: ScalaMongoDriver) extends MongoPersistenceJournallingApi {
+class ScalaDriverPersistenceJournaller(val driver: ScalaMongoDriver) extends MongoPersistenceJournallingApi {
 
   import driver.ScalaSerializers._
   import RxStreamsInterop._


### PR DESCRIPTION
* This will allow users of this library to provide an individual
  implementation of MetricsBuilder and define it as configuration
  property at akka.contrib.persistence.mongodb.mongo.metrics-builder.class
* Used same mechanism as used for bulding individual collection suffixes.
  See akka.contrib.persistence.mongodb.mongo.suffix-builder.class.
* With this mechanism vendor lock in for metric libraries can be avoided.
* Default behaviour is still the same like before (Using Dropwizard)
* Fixes #193

Signed-off-by: Klem Yannic (INST/ECS1) <Yannic.Klem@bosch-si.com>