### PR TITLE
allow to persist org.bson.BsonValue as passing DB object of type "bson"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val releaseV = "2.2.1"
+val releaseV = "2.2.2-SNAPSHOT"
 
 val scalaV = "2.11.8"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val releaseV = "2.2.2-SNAPSHOT"
+val releaseV = "2.2.1"
 
 val scalaV = "2.11.8"
 

--- a/docs/akka25.md
+++ b/docs/akka25.md
@@ -199,9 +199,9 @@ akka-contrib-persistence-dispatcher.thread-pool-executor.core-pool-size-max = 20
 
 If you need to see contents of your events directly in database in non-binary form, you can call `persist()` with a specific type that corresponds to the driver you use:
 
-* `org.scala.bson.BsonDocument` (using native scala driver)
-* `DBObject` (using casbah driver)
-* `BSONDocument` (using reactivemongo).
+* `org.bson.BsonValue` (using native scala driver)
+* `com.mongodb.DBObject` (using casbah driver)
+* `reactivemongo.bson.BSONDocument` (using reactivemongo).
 
 ```scala
 case class Command(value: String)

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceExtension.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceExtension.scala
@@ -16,7 +16,7 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
 
 class ScalaMongoDriver(system: ActorSystem, config: Config) extends MongoPersistenceDriver(system, config) {
-  override type C = Future[MongoCollection[D]]
+  override type C = Future[MongoCollection[BsonDocument]]
   override type D = BsonValue
 
   val ScalaSerializers: ScalaDriverSerializers = ScalaDriverSerializersExtension(system)
@@ -86,11 +86,11 @@ class ScalaMongoDriver(system: ActorSystem, config: Config) extends MongoPersist
     }
   }
 
-  private[mongodb] def getCollectionsAsFuture(collectionName: String)(implicit ec: ExecutionContext): Future[List[MongoCollection[D]]] = {
+  private[mongodb] def getCollectionsAsFuture(collectionName: String)(implicit ec: ExecutionContext): Future[List[MongoCollection[BsonDocument]]] = {
     getAllCollectionsAsFuture(Option(_.startsWith(collectionName)))
   }
 
-  private[mongodb] def getAllCollectionsAsFuture(nameFilter: Option[String => Boolean])(implicit ec: ExecutionContext): Future[List[MongoCollection[D]]] = {
+  private[mongodb] def getAllCollectionsAsFuture(nameFilter: Option[String => Boolean])(implicit ec: ExecutionContext): Future[List[MongoCollection[BsonDocument]]] = {
     def excluded(name: String): Boolean =
       name == realtimeCollectionName ||
         name == metadataCollectionName ||

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceExtension.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceExtension.scala
@@ -10,14 +10,14 @@ import com.mongodb.client.model.{CreateCollectionOptions, IndexOptions}
 import com.typesafe.config.Config
 import org.mongodb.scala.{MongoClientSettings, _}
 import model.Indexes._
-import org.mongodb.scala.bson.{BsonBoolean, BsonDocument}
+import org.mongodb.scala.bson.{BsonBoolean, BsonDocument, BsonValue}
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
 
 class ScalaMongoDriver(system: ActorSystem, config: Config) extends MongoPersistenceDriver(system, config) {
   override type C = Future[MongoCollection[D]]
-  override type D = Document
+  override type D = BsonValue
 
   val ScalaSerializers: ScalaDriverSerializers = ScalaDriverSerializersExtension(system)
   val scalaDriverSettings = ScalaDriverSettings(system)
@@ -70,7 +70,7 @@ class ScalaMongoDriver(system: ActorSystem, config: Config) extends MongoPersist
         .flatMap(_ => collection(name))
     }
 
-    db.listCollections().filter(Document("name" -> name)).toFuture().flatMap { collections =>
+    db.listCollections().filter(BsonDocument("name" -> name)).toFuture().flatMap { collections =>
       val capped = collections.headOption
         .flatMap(d => d.get("options"))
         .collect{ case d: BsonDocument if d.containsKey("capped") => d.get("capped").asBoolean() }

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceReadJournaller.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceReadJournaller.scala
@@ -129,7 +129,7 @@ object CurrentEventsByTag {
       .flatMapConcat(
         _.map(_.find(query).sort(ascending(ID)).asAkka)
          .reduceLeftOption(_ ++ _)
-         .getOrElse(Source.empty[driver.D])
+         .getOrElse(Source.empty[BsonDocument])
       ).map(_.asDocument)
        .map{ doc =>
         val id = doc.getObjectId(ID).getValue

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceSnapshotter.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceSnapshotter.scala
@@ -31,7 +31,7 @@ object ScalaDriverPersistenceSnapshotter extends SnapshottingFieldNames {
   def deserializeSnapshot(document: BsonDocument)(implicit serialization: Serialization): SelectedSnapshot = {
     if (document.contains(V1.SERIALIZED)) {
       (for {
-        content <- Option(document.get(V1.SERIALIZED)).map(_.asBinary()).map(_.getData)
+        content <- Option(document.get(V1.SERIALIZED)).filter(_.isBinary).map(_.asBinary).map(_.getData)
         ss      <- serialization.deserialize(content, classOf[SelectedSnapshot]).toOption
       } yield ss).get
     } else {
@@ -40,7 +40,7 @@ object ScalaDriverPersistenceSnapshotter extends SnapshottingFieldNames {
           o
         case _ =>
           (for {
-            content <- Option(document.get(V2.SERIALIZED)).map(_.asBinary()).map(_.getData)
+            content <- Option(document.get(V2.SERIALIZED)).filter(_.isBinary).map(_.asBinary).map(_.getData)
             snap    <- serialization.deserialize(content, classOf[Snapshot]).toOption
           } yield snap.data).get
       }

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceSnapshotter.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceSnapshotter.scala
@@ -3,7 +3,7 @@ import akka.persistence.serialization.Snapshot
 import akka.persistence.{SelectedSnapshot, SnapshotMetadata}
 import akka.serialization.Serialization
 import org.mongodb.scala._
-import org.mongodb.scala.bson.{BsonBinary, BsonDocument, BsonValue}
+import org.mongodb.scala.bson.{BsonBinary, BsonDocument}
 import org.mongodb.scala.model.Filters._
 import org.mongodb.scala.model.Indexes._
 import org.mongodb.scala.model.{IndexOptions, ReplaceOptions}
@@ -12,14 +12,14 @@ import scala.concurrent.{ExecutionContext, Future}
 
 object ScalaDriverPersistenceSnapshotter extends SnapshottingFieldNames {
 
-  def serializeSnapshot(snapshot: SelectedSnapshot)(implicit serialization: Serialization): BsonValue = {
+  def serializeSnapshot(snapshot: SelectedSnapshot)(implicit serialization: Serialization): BsonDocument = {
     val obj = BsonDocument(
       PROCESSOR_ID -> snapshot.metadata.persistenceId,
       SEQUENCE_NUMBER -> snapshot.metadata.sequenceNr,
       TIMESTAMP -> snapshot.metadata.timestamp
     )
     snapshot.snapshot match {
-      case o: BsonValue =>
+      case o: BsonDocument =>
         obj.append(V2.SERIALIZED, o)
       case _ =>
         Serialization.withTransportInformation(serialization.system) { () =>

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverSerializers.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverSerializers.scala
@@ -5,7 +5,6 @@ import akka.persistence.PersistentRepr
 import akka.serialization.{Serialization, SerializationExtension}
 import org.mongodb.scala._
 import org.mongodb.scala.bson._
-import org.mongodb.scala.bson.collection.immutable.Document
 
 import scala.collection.JavaConverters._
 
@@ -24,96 +23,100 @@ class ScalaDriverSerializers(dynamicAccess: DynamicAccess, actorSystem: ActorSys
   private implicit val system: ActorSystem = actorSystem
   implicit val loader: LoadClass = dynamicAccess
 
-  implicit val dt: DocumentType[Document] = new DocumentType[Document] { }
+  implicit val dt: DocumentType[BsonValue] = new DocumentType[BsonValue] { }
 
   object Version {
-    def unapply(doc: Document): Option[(Int,Document)] = {
-      doc.get[bson.BsonInt32](VERSION).map(_.intValue()).orElse(Option(0)).map(_ -> doc)
+    def unapply(doc: BsonDocument): Option[(Int,BsonDocument)] = {
+      Option(doc.get(VERSION)).map(_.asInt32()).map(_.intValue()).orElse(Option(0)).map(_ -> doc)
     }
   }
 
 
-  implicit object Deserializer extends CanDeserializeJournal[Document] {
-    override def deserializeDocument(dbo: Document): Event = dbo match {
-      case Version(1,d) => deserializeVersionOne(d)
-      case Version(0,d) => deserializeDocumentLegacy(d)
+  implicit object Deserializer extends CanDeserializeJournal[BsonValue] {
+    override def deserializeDocument(dbo: BsonValue): Event = dbo match {
+      case Version(1,d) => deserializeVersionOne(d.asDocument())
+      case Version(0,d) => deserializeDocumentLegacy(d.asDocument())
       case Version(x,_) => throw new IllegalStateException(s"Don't know how to deserialize version $x of document")
     }
 
-    private def extractTags(d: Document): Seq[String] =
-      d.get[bson.BsonArray](TAGS)
+    private def extractTags(d: BsonDocument): Seq[String] =
+      Option(d.get(TAGS)).map(_.asArray())
         .map(_.getValues.asScala.collect{ case s:bson.BsonString => s.getValue })
         .getOrElse(Seq.empty[String])
 
-    private def extractSender(d: Document): Option[ActorRef] =
-      d.get[bson.BsonBinary](SenderKey).map(_.getData).flatMap(serialization.deserialize(_, classOf[ActorRef]).toOption)
+    private def extractSender(d: BsonDocument): Option[ActorRef] =
+      Option(d.get(SenderKey)).map(_.asBinary())
+        .map(_.getData)
+        .flatMap(serialization.deserialize(_, classOf[ActorRef]).toOption)
 
     private def extractPayloadContent: PartialFunction[bson.BsonValue, Any] = {
       case bin: bson.BsonBinary => bin.getData
-      case doc: bson.BsonDocument => Document(doc)
+      case doc: bson.BsonDocument => doc
+      case arr: bson.BsonArray => arr
       case s: bson.BsonString => s.getValue
-      case dbl: bson.BsonDouble => dbl.doubleValue()
-      case dbl: bson.BsonDecimal128 => dbl.doubleValue()
+      case dbl: bson.BsonDouble => dbl.doubleValue
+      case dbl: bson.BsonDecimal128 => dbl.doubleValue
       case lng: bson.BsonInt64 => lng.getValue
+      case int: bson.BsonInt32 => int.getValue
       case bl: bson.BsonBoolean => bl.getValue
     }
 
-    private def deserializeVersionOne(d: Document) = Event(
-      pid = d.getString(PROCESSOR_ID),
+    private def deserializeVersionOne(d: BsonDocument) = Event(
+      pid = d.getString(PROCESSOR_ID).getValue,
       sn = d.getLong(SEQUENCE_NUMBER),
-      payload = Payload[Document](
-        hint = d.getString(TYPE),
-        any = d.get[bson.BsonValue](PayloadKey).collect(extractPayloadContent).get,
+      payload = Payload[BsonValue](
+        hint = d.getString(TYPE).getValue,
+        any = Option(d.get(PayloadKey)).collect(extractPayloadContent).get,
         tags = Set.empty[String] ++ extractTags(d),
-        clazzName = d.get[BsonString](HINT).map(_.getValue),
-        serId = d.get[BsonInt32](SER_ID).map(_.getValue),
-        serManifest = d.get[BsonString](SER_MANIFEST).map(_.getValue)
+        clazzName = Option(d.get(HINT)).map(_.asString).map(_.getValue),
+        serId = Option(d.get(SER_ID)).map(_.asInt32()).map(_.getValue),
+        serManifest = Option(d.get(SER_MANIFEST)).map(_.asString()).map(_.getValue)
       ),
       sender = extractSender(d),
-      manifest = d.get[BsonString](MANIFEST).map(_.getValue),
-      writerUuid = d.get[BsonString](WRITER_UUID).map(_.getValue)
+      manifest = Option(d.get(MANIFEST)).map(_.asString()).map(_.getValue),
+      writerUuid = Option(d.get(WRITER_UUID)).map(_.asString()).map(_.getValue)
     )
 
-    private def deserializeDocumentLegacy(d: Document) = {
-      val persistenceId = d.getString(PROCESSOR_ID)
+    private def deserializeDocumentLegacy(d: BsonDocument) = {
+      val persistenceId = d.getString(PROCESSOR_ID).getValue
       val sequenceNr = d.getLong(SEQUENCE_NUMBER)
-      d.get[BsonDocument](SERIALIZED) match {
+      Option(d.get(SERIALIZED)) match {
         case Some(b: BsonDocument) =>
           Event(
             pid = persistenceId,
             sn = sequenceNr,
-            payload = Bson(Document(b.getDocument(PayloadKey).asScala), Set()),
+            payload = Bson[BsonValue](b.getDocument(PayloadKey), Set()),
             sender = extractSender(b),
             manifest = None,
             writerUuid = None
           )
         case _ =>
           val repr = (for {
-            content <- d.get[bson.BsonBinary](SERIALIZED)
+            content <- Option(d.get(SERIALIZED)).map(_.asBinary())
             buf = content.getData
             pr <- serialization.deserialize(buf, classOf[PersistentRepr]).toOption
           } yield pr).get
-          Event[Document](useLegacySerialization = false)(repr).copy(pid = persistenceId, sn = sequenceNr)
+          Event[BsonValue](useLegacySerialization = false)(repr).copy(pid = persistenceId, sn = sequenceNr)
       }
 
     }
   }
 
-  implicit object Serializer extends CanSerializeJournal[Document] with DefaultBsonTransformers {
-    override def serializeAtom(atom: Atom): Document = {
+  implicit object Serializer extends CanSerializeJournal[BsonValue] with DefaultBsonTransformers {
+    override def serializeAtom(atom: Atom): BsonValue = {
       Option(atom.tags).filter(_.nonEmpty).foldLeft(
-        Document(
+        BsonDocument(
           PROCESSOR_ID -> atom.pid,
           FROM -> atom.from,
           TO -> atom.to,
           EVENTS -> atom.events.map(serializeEvent),
           VERSION -> 1
         )
-      ){ case(o,tags) => o + (TAGS -> tags.toSeq)}
+      ){ case(o,tags) => o.append(TAGS, BsonArray(tags.toSeq))}
     }
 
-    private def serializeEvent(event: Event): Document = {
-      val b = serializePayload(event.payload)(Document(
+    private def serializeEvent(event: Event): BsonValue = {
+      val b = serializePayload(event.payload)(BsonDocument(
           VERSION -> 1,
           PROCESSOR_ID -> event.pid,
           SEQUENCE_NUMBER -> event.sn,
@@ -121,32 +124,32 @@ class ScalaDriverSerializers(dynamicAccess: DynamicAccess, actorSystem: ActorSys
         ))
       (for {
         doc <- Option(b)
-        doc <- Option(event.tags).filter(_.nonEmpty).map(tags => doc + (TAGS -> tags.toSeq)).orElse(Option(doc))
-        doc <- event.manifest.map(s => doc + (MANIFEST -> s)).orElse(Option(doc))
-        doc <- event.writerUuid.map(s => doc + (WRITER_UUID -> s)).orElse(Option(doc))
+        doc <- Option(event.tags).filter(_.nonEmpty).map(tags => doc.append(TAGS, BsonArray(tags.toSeq))).orElse(Option(doc))
+        doc <- event.manifest.map(s => doc.append(MANIFEST, BsonString(s))).orElse(Option(doc))
+        doc <- event.writerUuid.map(s => doc.append(WRITER_UUID, BsonString(s))).orElse(Option(doc))
         doc <- event.sender
           .filterNot(_ == system.deadLetters)
           .flatMap(serialization.serialize(_).toOption)
-          .map(s => doc + (SenderKey -> s)).orElse(Option(doc))
+          .map(s => doc.append(SenderKey, BsonBinary(s))).orElse(Option(doc))
       } yield doc).getOrElse(b)
     }
 
-    private def serializePayload(payload: Payload)(doc: Document): Document = {
-      val withType = doc + (TYPE -> payload.hint)
+    private def serializePayload(payload: Payload)(doc: BsonDocument): BsonDocument = {
+      val withType = doc.append(TYPE, BsonString(payload.hint))
       payload match {
-        case Bson(doc: Document, _) => withType + (PayloadKey -> doc)
-        case Bin(bytes, _) => withType + (PayloadKey -> bytes)
-        case Legacy(bytes, _) => withType + (PayloadKey -> bytes)
+        case Bson(doc: BsonValue, _) => withType.append(PayloadKey, doc)
+        case Bin(bytes, _) => withType.append(PayloadKey, BsonBinary(bytes))
+        case Legacy(bytes, _) => withType.append(PayloadKey, BsonBinary(bytes))
         case s: Serialized[_] =>
-          withType +
-            (PayloadKey -> s.bytes) +
-            (HINT -> s.className) +
-            (SER_MANIFEST -> s.serializedManifest) +
-            (SER_ID -> s.serializerId)
-        case StringPayload(str, _) => withType + (PayloadKey -> str)
-        case FloatingPointPayload(d, _) => withType + (PayloadKey -> d)
-        case FixedPointPayload(l, _) => withType + (PayloadKey -> l)
-        case BooleanPayload(bl, _) => withType + (PayloadKey -> bl)
+          withType
+            .append(PayloadKey, BsonBinary(s.bytes))
+            .append(HINT, BsonString(s.className))
+            .append(SER_MANIFEST, s.serializedManifest.map(BsonString(_)).getOrElse(BsonNull()))
+            .append(SER_ID, s.serializerId.map(BsonInt32(_)).getOrElse(BsonNull()))
+        case StringPayload(str, _) => withType.append(PayloadKey, BsonString(str))
+        case FloatingPointPayload(d, _) => withType.append(PayloadKey, BsonDouble(d))
+        case FixedPointPayload(l, _) => withType.append(PayloadKey, BsonInt64(l))
+        case BooleanPayload(bl, _) => withType.append(PayloadKey, BsonBoolean(bl))
         case x => throw new IllegalArgumentException(s"Unable to serialize payload for unknown type ${x.getClass.getName} with hint ${payload.hint}")
       }
     }

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverSerializers.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverSerializers.scala
@@ -85,7 +85,7 @@ class ScalaDriverSerializers(dynamicAccess: DynamicAccess, actorSystem: ActorSys
           Event(
             pid = persistenceId,
             sn = sequenceNr,
-            payload = Bson[BsonValue](b.getDocument(PayloadKey), Set()),
+            payload = Bson[BsonValue](b.get(PayloadKey), Set()),
             sender = extractSender(b),
             manifest = None,
             writerUuid = None


### PR DESCRIPTION
for event journal and snapshots.
Fixes: #215 

Had to adjust the "getters" usage on `BsonDocument` as this differed from the previously used `Document`
I verified that this works with our (Eclipse Ditto) codebase - hopefully the tests will also approve :)