### PR TITLE
Allow to exclude dropwizard dependency

### DIFF
--- a/common/src/main/scala/akka/contrib/persistence/mongodb/MongoMetrics.scala
+++ b/common/src/main/scala/akka/contrib/persistence/mongodb/MongoMetrics.scala
@@ -124,7 +124,7 @@ private class DropwizardHistogram(dropwizardHistogram: Histogram) extends MongoH
 private[mongodb] object DropwizardMetrics extends MetricsBuilder with InstrumentedBuilder {
 
   override lazy val metricBaseName: MetricName = MetricName("")
-  override val metricRegistry: MetricRegistry = SharedMetricRegistries.getOrCreate("mongodb")
+  override lazy val metricRegistry: MetricRegistry = SharedMetricRegistries.getOrCreate("mongodb")
 
   private def timerName(metric: String) = MetricName(metric, "timer").name
 


### PR DESCRIPTION
As mentioned by @gbrd in #193 it is not possible right now to exclude the dropwizard dependency even if using a custom MetricBuilder.

This is because I kept the field metricRegistry for backwards compatibility reasons.
Making this field lazy solves that problem.