### PR TITLE
Issue #219 - IDs should match between journal & realtime

### DIFF
--- a/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahSerializers.scala
+++ b/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahSerializers.scala
@@ -5,6 +5,7 @@ import akka.persistence.PersistentRepr
 import akka.serialization.{Serialization, SerializationExtension}
 import com.mongodb.DBObject
 import com.mongodb.casbah.Imports._
+import org.bson.types.ObjectId
 
 object CasbahSerializersExtension extends ExtensionId[CasbahSerializers] with ExtensionIdProvider {
   override def lookup = CasbahSerializersExtension
@@ -80,6 +81,7 @@ class CasbahSerializers(dynamicAccess: DynamicAccess, actorSystem: ActorSystem) 
     override def serializeAtom(atom: Atom): DBObject = {
       Option(atom.tags).filter(_.nonEmpty).foldLeft(
         MongoDBObject(
+          ID -> ObjectId.get(),
           PROCESSOR_ID -> atom.pid,
           FROM -> atom.from,
           TO -> atom.to,

--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoSerializers.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoSerializers.scala
@@ -164,6 +164,7 @@ class RxMongoSerializers(dynamicAccess: DynamicAccess, actorSystem: ActorSystem)
     override def serializeAtom(atom: Atom): BSONDocument = {
       Option(atom.tags).filter(_.nonEmpty).foldLeft(
         BSONDocument(
+          ID -> BSONObjectID.generate(),
           PROCESSOR_ID -> atom.pid,
           FROM -> atom.from,
           TO -> atom.to,

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceJournaller.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceJournaller.scala
@@ -1,4 +1,10 @@
+/*
+ * Copyright (c) 2018-2019 Brian Scully
+ *
+ */
+
 package akka.contrib.persistence.mongodb
+
 import akka.actor.ActorSystem
 import akka.persistence.{AtomicWrite, PersistentRepr}
 import akka.stream.{ActorMaterializer, Materializer}
@@ -14,8 +20,8 @@ import model.Projections._
 import org.mongodb.scala.bson.{BsonDocument, BsonValue}
 import org.slf4j.{Logger, LoggerFactory}
 
-import scala.collection.{JavaConverters, immutable}
-import JavaConverters._
+import scala.collection.JavaConverters._
+import scala.collection.immutable.Seq
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
@@ -61,7 +67,7 @@ class ScalaDriverPersistenceJournaller(val driver: ScalaMongoDriver) extends Mon
       .mapConcat[Event](e =>
         Option(e.get(EVENTS)).filter(_.isArray).map(_.asArray).map(_.getValues.asScala.toList.collect {
           case d: BsonDocument => driver.deserializeJournal(d)
-        }).getOrElse(immutable.Seq.empty[Event])
+        }).getOrElse(Seq.empty[Event])
       )
       .filter(_.sn >= from)
       .filter(_.sn <= to)
@@ -69,28 +75,28 @@ class ScalaDriverPersistenceJournaller(val driver: ScalaMongoDriver) extends Mon
     source.via(flow)
   }
 
-  private[this] def doBatchAppend(writes: immutable.Seq[AtomicWrite], collection: driver.C)(implicit ec: ExecutionContext): Future[immutable.Seq[Try[Unit]]] = {
-    val batch = writes.map(aw => Try(driver.serializeJournal(Atom[BsonValue](aw, driver.useLegacySerialization))))
+  private[this] def buildBatch(writes: Seq[AtomicWrite]): Seq[Try[BsonDocument]] =
+    writes.map(aw => Try(driver.serializeJournal(Atom[BsonValue](aw, driver.useLegacySerialization))))
 
+  private[this] def doBatchAppend(batch: Seq[Try[BsonDocument]], collection: driver.C)(implicit ec: ExecutionContext): Future[Seq[Try[BsonDocument]]] = {
     if (batch.forall(_.isSuccess)) {
       val collected: Seq[InsertOneModel[driver.D]] = batch.collect { case Success(doc) => InsertOneModel(doc) }
       collection.flatMap(_.withWriteConcern(writeConcern).bulkWrite(collected, new BulkWriteOptions().ordered(true))
         .toFuture()
-        .map(_ => batch.map(_.map(_ => ()))))
+        .map(_ => batch))
     } else {
       Future.sequence(batch.map {
         case Success(document: BsonDocument) =>
-          collection.flatMap(_.withWriteConcern(writeConcern).insertOne(document).toFuture().map(_ => Success(())))
+          collection.flatMap(_.withWriteConcern(writeConcern).insertOne(document).toFuture().map(_ => Success(document)))
         case f: Failure[_] =>
-          Future.successful(Failure[Unit](f.exception))
+          Future.successful(Failure[BsonDocument](f.exception))
       })
     }
   }
 
-
-  override private[mongodb] def batchAppend(writes: immutable.Seq[AtomicWrite])(implicit ec: ExecutionContext): Future[immutable.Seq[Try[Unit]]] = {
+  override private[mongodb] def batchAppend(writes: Seq[AtomicWrite])(implicit ec: ExecutionContext): Future[Seq[Try[Unit]]] = {
     val batchFuture = if (driver.useSuffixedCollectionNames) {
-      val fZero = Future.successful(immutable.Seq.empty[Try[Unit]])
+      val fZero = Future.successful(Seq.empty[Try[BsonDocument]])
 
       // this should guarantee that futures are performed sequentially...
       writes
@@ -98,18 +104,28 @@ class ScalaDriverPersistenceJournaller(val driver: ScalaMongoDriver) extends Mon
         .foldLeft(fZero) { case (future, (_, hunk)) =>
           for {
             prev <- future
-            next <- doBatchAppend(hunk, driver.journal(hunk.head.persistenceId))
+            batch = buildBatch(hunk)
+            next <- doBatchAppend(batch, driver.journal(hunk.head.persistenceId))
           } yield prev ++ next
         }
 
     } else {
-      doBatchAppend(writes, journal)
+      val batch = buildBatch(writes)
+      doBatchAppend(batch, journal)
     }
 
     if (driver.realtimeEnablePersistence)
-      batchFuture.andThen { case _ => doBatchAppend(writes, realtime) }
+      batchFuture.andThen {
+        case Success(batch) =>
+          val f = doBatchAppend(batch, realtime)
+          f.onFailure {
+            case t =>
+              logger.error("Error during write to realtime collection", t)
+          }
+          f
+      }.map(squashToUnit)
     else
-      batchFuture
+      batchFuture.map(squashToUnit)
   }
 
   private[this] def setMaxSequenceMetadata(persistenceId: String, maxSequenceNr: Long)(implicit ec: ExecutionContext): Future[Unit] = {

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverSerializers.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverSerializers.scala
@@ -106,6 +106,7 @@ class ScalaDriverSerializers(dynamicAccess: DynamicAccess, actorSystem: ActorSys
     override def serializeAtom(atom: Atom): BsonDocument = {
       Option(atom.tags).filter(_.nonEmpty).foldLeft(
         BsonDocument(
+          ID -> BsonObjectId(),
           PROCESSOR_ID -> atom.pid,
           FROM -> atom.from,
           TO -> atom.to,


### PR DESCRIPTION
* Generate IDs before sending to mongo, reuse serialized documents
* Log error if realtime write fails
* Clean up some deprecation warnings and other code warnings