### PR TITLE
Bugfix/213

### DIFF
--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/MongoErrors.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/MongoErrors.scala
@@ -1,0 +1,15 @@
+package akka.contrib.persistence.mongodb
+
+import com.mongodb.MongoCommandException
+
+object MongoErrors {
+
+  object NamespaceExists extends CommandExceptionErrorCode(48)
+
+}
+
+abstract class CommandExceptionErrorCode(expectedErrorCode: Int) {
+
+  def unapply(scrutinee: MongoCommandException): Boolean =
+    expectedErrorCode == scrutinee.getErrorCode
+}


### PR DESCRIPTION
Fix #213 for the official scala driver.

This patch adds simple handling of `NamespaceExists` error to `ScalaDriverPersistenceExtension` when it creates collections, capped or otherwise. I chose not to call `ensureCollection` in `cappedCollection` yet, because the collection creation methods have remaining issues to be addressed in another PR after our internal code review. The leftover issues are:
- Indexes of a journal collection are not re-created if someone else drops the journal collection,
- Collection creators often use the global execution context or the actor system's default dispatcher instead of the configured dispatcher for the plugin. It threatens thread starvation when used together with a blocking driver.