### PR TITLE
Improve collection creation for long-running systems under high load

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ def commonDeps(sv:String) = Seq(
     .exclude("com.typesafe.akka", "akka-actor_2.11")
     .exclude("com.typesafe.akka", "akka-actor_2.12"),
   "com.typesafe.akka"         %% "akka-persistence-query"   % AkkaV     % "provided",
+  "org.mongodb"               % "mongodb-driver-core"       % "3.8.2"   % "compile",
   "org.mongodb"               % "mongodb-driver"            % "3.8.2"   % "test",
   "org.slf4j"                 % "slf4j-api"                 % "1.7.22"  % "test",
   "org.apache.logging.log4j"  % "log4j-api"                 % "2.5"     % "test",

--- a/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceExtension.scala
+++ b/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahPersistenceExtension.scala
@@ -50,10 +50,10 @@ class CasbahMongoDriver(system: ActorSystem, config: Config) extends MongoPersis
 
   private[mongodb] lazy val db = client(databaseName.getOrElse(url.database.getOrElse(DEFAULT_DB_NAME)))
 
-  private[mongodb] def collection(name: String) = db(name)
+  private[mongodb] override def collection(name: String)(implicit ec: ExecutionContext) = db(name)
 
   private val NamespaceExistsErrorCode = 48
-  private[mongodb] override def ensureCollection(name: String): MongoCollection = {
+  private[mongodb] override def ensureCollection(name: String)(implicit ec: ExecutionContext): MongoCollection = {
     if (!db.collectionExists(name)) {
       try {
         db.createCollection(name, BasicDBObjectBuilder.start().get()).asScala
@@ -98,7 +98,7 @@ class CasbahMongoDriver(system: ActorSystem, config: Config) extends MongoPersis
     }
   }
 
-  private[mongodb] def getCollections(collectionName: String): List[C] = {
+  private[mongodb] def getCollections(collectionName: String)(implicit ec: ExecutionContext): List[C] = {
     def excludeNames(name: String): Boolean =
       name == realtimeCollectionName ||
         name == metadataCollectionName ||
@@ -107,9 +107,9 @@ class CasbahMongoDriver(system: ActorSystem, config: Config) extends MongoPersis
     db.collectionNames().filterNot(excludeNames).filter(_.startsWith(collectionName)).map(collection).toList
   }
 
-  private[mongodb] def getJournalCollections: List[C] = getCollections(journalCollectionName)
+  private[mongodb] def getJournalCollections(implicit ec: ExecutionContext): List[C] = getCollections(journalCollectionName)
 
-  private[mongodb] def getSnapshotCollections: List[C] = getCollections(snapsCollectionName)
+  private[mongodb] def getSnapshotCollections(implicit ec: ExecutionContext): List[C] = getCollections(snapsCollectionName)
 
 }
 

--- a/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahPersistenceSpec.scala
+++ b/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahPersistenceSpec.scala
@@ -10,19 +10,19 @@ import akka.testkit.TestKit
 import com.mongodb.casbah.{MongoClient, MongoCollection}
 import com.typesafe.config.ConfigFactory
 
-import scala.language.postfixOps
+import scala.concurrent.ExecutionContext
 
 trait CasbahPersistenceSpec extends MongoPersistenceSpec[CasbahMongoDriver, MongoCollection] { self: TestKit =>
 
   lazy val mongoDB = MongoClient(host, noAuthPort)(embedDB)
 
   override val driver = new CasbahMongoDriver(system, ConfigFactory.empty()) {
-    override def collection(name: String) = mongoDB(name)
+    override def collection(name: String)(implicit ec: ExecutionContext) = mongoDB(name)
     override lazy val db = mongoDB
   }
 
   override val extendedDriver = new CasbahMongoDriver(system, ConfigFactory.parseString(SuffixCollectionNamesTest.overriddenConfig)) {
-    override def collection(name: String) = mongoDB(name)
+    override def collection(name: String)(implicit ec: ExecutionContext) = mongoDB(name)
     override lazy val db = mongoDB
   }
 

--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -83,15 +83,24 @@ akka {
 
             # Cache of one realtime collection
             realtime {
-              // TODO: create default cache for caching one collection
               class = ""
               expire-after-write = Infinity
+
+              # maximum size of the cache
+              # 1 because the realtime collection is unique
+              # default caches do not honor size bounds bigger than 1
+              max-size = 1
             }
 
             # Cache of one metadata collection
             metadata {
               class = ""
               expire-after-write = Infinity
+
+              # maximum size of the cache
+              # 1 because the metadata collection is unique
+              # default caches do not honor size bounds bigger than 1
+              max-size = 1
             }
           }
         }

--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -57,7 +57,30 @@ akka {
 
           # Set to true to drop suffixed collections when empty
           suffix-drop-empty-collections = false
-          
+
+          # Caches of collections created by the plugin
+          collection-cache {
+
+            # Cache of journal collections
+            journal {
+              # Implementation of the cache.
+              # - Must be a subtype of MongoCollectionCache.
+              # - Must have a public constructor taking a Config object as argument.
+              # - Must be able to store the collection type of the chosen driver.
+              #
+              # If left empty, a default naive implementation with unbound memory consumption is used.
+              class = ""
+
+              # How long to retain the collection. Invalid or missing durations are treated as eternity.
+              expire-after-write = Infinity
+            }
+
+            # Cache of snapshot collections
+            snaps {
+              class = ""
+              expire-after-write = Infinity
+            }
+          }
         }
       }
     }

--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -80,6 +80,19 @@ akka {
               class = ""
               expire-after-write = Infinity
             }
+
+            # Cache of one realtime collection
+            realtime {
+              // TODO: create default cache for caching one collection
+              class = ""
+              expire-after-write = Infinity
+            }
+
+            # Cache of one metadata collection
+            metadata {
+              class = ""
+              expire-after-write = Infinity
+            }
           }
         }
       }

--- a/common/src/main/scala/akka/contrib/persistence/mongodb/MongoCollectionCache.scala
+++ b/common/src/main/scala/akka/contrib/persistence/mongodb/MongoCollectionCache.scala
@@ -1,0 +1,95 @@
+package akka.contrib.persistence.mongodb
+
+import java.time.{Duration, Instant}
+
+import com.typesafe.config.Config
+
+import scala.collection.concurrent.TrieMap
+import scala.util.{Success, Try}
+
+trait MongoCollectionCache[C] {
+
+  /**
+    * Retrieve a collection from the cache if it exists or otherwise create it using an IDEMPOTENT procedure.
+    *
+    * @param collectionName    Name of the collection.
+    * @param collectionCreator Creator of the collection. Must be idempotent.
+    */
+  def getOrElseCreate(collectionName: String, collectionCreator: String => C): C
+
+  def invalidate(collectionName: String): Unit
+}
+
+object MongoCollectionCache {
+
+  def apply[C](config: Config, path: String): MongoCollectionCache[C] = {
+    val configuredCache =
+      for {
+        className <- Try(config.getString(s"$path.class"))
+        constructor <- loadCacheConstructor[C](className)
+      } yield constructor.apply(config.getConfig(path))
+
+    configuredCache.getOrElse(createDefaultCache(config, path))
+  }
+
+  /**
+    * Naive cache that retains cached collections forever.
+    *
+    * @tparam C Collection type.
+    */
+  case class Default[C]() extends MongoCollectionCache[C] {
+
+    private[this] val trieMap: TrieMap[String, C] = TrieMap.empty[String, C]
+
+    override def getOrElseCreate(collectionName: String, collectionCreator: String => C): C =
+      trieMap.getOrElseUpdate(collectionName, collectionCreator.apply(collectionName))
+
+    override def invalidate(collectionName: String): Unit =
+      trieMap.remove(collectionName)
+  }
+
+  /**
+    * Naive implementation of a cache whose entries expire after a period of time.
+    * Memory consumption is not bounded.
+    *
+    * @param expireAfterWrite Duration that a cached collection remains valid.
+    * @tparam C Collection type.
+    */
+  case class Expiring[C](expireAfterWrite: Duration) extends MongoCollectionCache[C] {
+
+    private[this] val trieMap: TrieMap[String, (Instant, C)] = TrieMap.empty[String, (Instant, C)]
+
+    override def getOrElseCreate(collectionName: String, collectionCreator: String => C): C = {
+      val (createdAt, collection) =
+        trieMap.getOrElseUpdate(collectionName, (Instant.now, collectionCreator.apply(collectionName)))
+      val now = Instant.now
+      if (createdAt.plus(expireAfterWrite).isBefore(now)) {
+        val recreatedCollection = collectionCreator.apply(collectionName)
+        trieMap.put(collectionName, (now, recreatedCollection))
+        recreatedCollection
+      } else {
+        collection
+      }
+    }
+
+    override def invalidate(collectionName: String): Unit =
+      trieMap.remove(collectionName)
+  }
+
+  private[this] def loadCacheConstructor[C](className: String): Try[Config => MongoCollectionCache[C]] =
+    for {
+      nonEmptyClassName <- Success(className.trim).filter(_.nonEmpty)
+      cacheClass <- Try(Class.forName(nonEmptyClassName))
+      // if the loaded class implements MongoCollectionCache, take it on faith that it can store C
+      if classOf[MongoCollectionCache[_]].isAssignableFrom(cacheClass)
+      constructor <- getExpectedConstructor(cacheClass.asInstanceOf[Class[MongoCollectionCache[C]]])
+    } yield constructor
+
+  private[this] def getExpectedConstructor[T](cacheClass: Class[T]): Try[Config => T] =
+    Try(cacheClass.getConstructor(classOf[Config])).map(constructor => x => constructor.newInstance(x))
+
+  private[this] def createDefaultCache[C](config: Config, path: String): MongoCollectionCache[C] =
+    Try(config.getDuration(s"$path.expire-after-write"))
+      .map[MongoCollectionCache[C]](Expiring.apply)
+      .getOrElse(Default())
+}

--- a/common/src/main/scala/akka/contrib/persistence/mongodb/MongoErrors.scala
+++ b/common/src/main/scala/akka/contrib/persistence/mongodb/MongoErrors.scala
@@ -8,8 +8,8 @@ object MongoErrors {
 
 }
 
-abstract class CommandExceptionErrorCode(expectedErrorCode: Int) {
+abstract class CommandExceptionErrorCode(val code: Int) {
 
   def unapply(scrutinee: MongoCommandException): Boolean =
-    expectedErrorCode == scrutinee.getErrorCode
+    code == scrutinee.getErrorCode
 }

--- a/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistence.scala
+++ b/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistence.scala
@@ -184,7 +184,7 @@ abstract class MongoPersistenceDriver(as: ActorSystem, config: Config)
     IndexSettings(journalTagIndexName, unique = false, sparse = true, TAGS -> 1)
   )
 
-  private[this] val journalCache = MongoCollectionCache[C](config, "collection-cache.journal")
+  private[this] val journalCache = MongoCollectionCache[C](settings.CollectionCache, "journal")
 
   private[mongodb] def journal(implicit ec: ExecutionContext): C = journal("")
 
@@ -206,7 +206,7 @@ abstract class MongoPersistenceDriver(as: ActorSystem, config: Config)
     journalCache.invalidate(collectionName)
   }
 
-  private[this] val snapsCache = MongoCollectionCache[C](config, "collection-cache.snaps")
+  private[this] val snapsCache = MongoCollectionCache[C](settings.CollectionCache, "snaps")
 
   private[mongodb] def snaps(implicit ec: ExecutionContext): C = snaps("")
 
@@ -227,14 +227,14 @@ abstract class MongoPersistenceDriver(as: ActorSystem, config: Config)
     snapsCache.invalidate(collectionName)
   }
 
-  private[this] val realtimeCache = MongoCollectionCache[C](config, "collection-cache.realtime")
+  private[this] val realtimeCache = MongoCollectionCache[C](settings.CollectionCache, "realtime")
 
   private[mongodb] def realtime(implicit ec: ExecutionContext): C =
     realtimeCache.getOrElseCreate(realtimeCollectionName, collectionName => cappedCollection(collectionName))
 
   private[mongodb] val querySideDispatcher = actorSystem.dispatchers.lookup("akka-contrib-persistence-query-dispatcher")
 
-  private[this] val metadataCache = MongoCollectionCache[C](config, "collection-cache.metadata")
+  private[this] val metadataCache = MongoCollectionCache[C](settings.CollectionCache, "metadata")
 
   private[mongodb] def metadata(implicit ec: ExecutionContext): C =
     metadataCache.getOrElseCreate(metadataCollectionName, collectionName => {

--- a/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistenceExtension.scala
+++ b/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistenceExtension.scala
@@ -114,4 +114,6 @@ class MongoSettings(val config: Config) {
   val SuffixDropEmptyCollections: Boolean = config.getBoolean("suffix-drop-empty-collections")
 
   val MongoMetricsBuilderClass: String = config.getString("metrics-builder.class")
+
+  val CollectionCache: Config = config.getConfig("collection-cache")
 }

--- a/common/src/main/scala/akka/contrib/persistence/mongodb/WithMongoPersistencePluginDispatcher.scala
+++ b/common/src/main/scala/akka/contrib/persistence/mongodb/WithMongoPersistencePluginDispatcher.scala
@@ -1,0 +1,20 @@
+package akka.contrib.persistence.mongodb
+
+import akka.actor.ActorSystem
+import com.typesafe.config.{Config, ConfigException}
+
+import scala.concurrent.ExecutionContextExecutor
+import scala.util.{Failure, Success, Try}
+
+abstract class WithMongoPersistencePluginDispatcher(actorSystem: ActorSystem, config: Config) {
+
+  implicit lazy val pluginDispatcher: ExecutionContextExecutor =
+    Try(actorSystem.dispatchers.lookup(config.getString("plugin-dispatcher"))) match {
+      case Success(configuredPluginDispatcher) =>
+        configuredPluginDispatcher
+      case Failure(_ : ConfigException) =>
+        actorSystem.log.warning("plugin-dispatcher not configured for akka-contrib-mongodb-persistence. " +
+          "Using actor system dispatcher.")
+        actorSystem.dispatcher
+    }
+}

--- a/common/src/test/scala/akka/contrib/persistence/mongodb/ReadJournalSpec.scala
+++ b/common/src/test/scala/akka/contrib/persistence/mongodb/ReadJournalSpec.scala
@@ -49,8 +49,15 @@ abstract class ReadJournalSpec[A <: MongoPersistenceExtension](extensionClass: C
 
   def config(extensionClass: Class[_]): Config = ConfigFactory.parseString(s"""
     |include "/application.conf"
-    |akka.contrib.persistence.mongodb.mongo.driver = "${extensionClass.getName}"
-    |akka.contrib.persistence.mongodb.mongo.mongouri = "mongodb://$host:$noAuthPort/$embedDB"
+    |akka.contrib.persistence.mongodb.mongo {
+    |  driver = "${extensionClass.getName}"
+    |  mongouri = "mongodb://$host:$noAuthPort/$embedDB"
+    |  collection-cache {
+    |    // disable caching of journal and realtime collections - spec drops them between tests
+    |    journal.expire-after-write = -1s
+    |    realtime.expire-after-write = -1s
+    |  }
+    |}
     |akka.persistence.journal.plugin = "akka-contrib-mongodb-persistence-journal"
     |akka-contrib-mongodb-persistence-journal {
     |    # Class name of the plugin.

--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoJournaller.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoJournaller.scala
@@ -35,9 +35,9 @@ class RxMongoJournaller(val driver: RxMongoDriver) extends MongoPersistenceJourn
 
   private[this] def journal(implicit ec: ExecutionContext) = driver.journal
 
-  private[this] def realtime = driver.realtime
+  private[this] def realtime(implicit ec: ExecutionContext) = driver.realtime
 
-  private[this] def metadata = driver.metadata
+  private[this] def metadata(implicit ec: ExecutionContext) = driver.metadata
 
   private[this] def journalRangeQuery(pid: String, from: Long, to: Long) = BSONDocument(
     PROCESSOR_ID -> pid,

--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceExtension.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceExtension.scala
@@ -96,7 +96,8 @@ class RxMongoDriver(system: ActorSystem, config: Config, driverProvider: RxMongo
       retries = rxMSettings.Retries,
       delayFactor = rxMSettings.GrowthFunction)
   }
-  private[mongodb] def db = connection.database(name = dbName, failoverStrategy = failoverStrategy)(system.dispatcher)
+  private[mongodb] def db(implicit ec: ExecutionContext): Future[DefaultDB] =
+    connection.database(name = dbName, failoverStrategy = failoverStrategy)
 
   private[mongodb] override def collection(name: String)(implicit ec: ExecutionContext) = db.map(_[BSONCollection](name))
 

--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceExtension.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceExtension.scala
@@ -98,10 +98,10 @@ class RxMongoDriver(system: ActorSystem, config: Config, driverProvider: RxMongo
   }
   private[mongodb] def db = connection.database(name = dbName, failoverStrategy = failoverStrategy)(system.dispatcher)
 
-  private[mongodb] override def collection(name: String) = db.map(_[BSONCollection](name))(system.dispatcher)
+  private[mongodb] override def collection(name: String)(implicit ec: ExecutionContext) = db.map(_[BSONCollection](name))(system.dispatcher)
 
   private val NamespaceExistsErrorCode = 48
-  private[mongodb] override def ensureCollection(name: String): Future[BSONCollection] = {
+  private[mongodb] override def ensureCollection(name: String)(implicit ec: ExecutionContext): Future[BSONCollection] = {
     implicit val ec: ExecutionContext = system.dispatcher
     for {
       coll <- collection(name)

--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceExtension.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceExtension.scala
@@ -103,8 +103,8 @@ class RxMongoDriver(system: ActorSystem, config: Config, driverProvider: RxMongo
   private[mongodb] override def ensureCollection(name: String)(implicit ec: ExecutionContext): Future[BSONCollection] =
     ensureCollection(name, _.create())
 
-  private[mongodb] def ensureCollection(name: String, collectionCreator: BSONCollection => Future[Unit])
-                                       (implicit ec: ExecutionContext): Future[BSONCollection] = {
+  private[this] def ensureCollection(name: String, collectionCreator: BSONCollection => Future[Unit])
+                                    (implicit ec: ExecutionContext): Future[BSONCollection] = {
     for {
       coll <- collection(name)
       _ <- collectionCreator(coll).recover { case CommandError.Code(MongoErrors.NamespaceExists.code) => coll }

--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceExtension.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceExtension.scala
@@ -67,8 +67,8 @@ class RxMongoDriver(system: ActorSystem, config: Config, driverProvider: RxMongo
     // create unauthenticated connection, there is no direct way to wait for authentication this way
     // plus prevent sending double authentication (initial authenticate and our explicit authenticate)
     driver.connection(parsedURI = parsedMongoUri.copy(authenticate = None))
-      .database(name = dbName, failoverStrategy = failoverStrategy)(system.dispatcher)
-      .map(_.connection)(system.dispatcher)
+      .database(name = dbName, failoverStrategy = failoverStrategy)
+      .map(_.connection)
   }
 
   private[mongodb] lazy val connection: MongoConnection =
@@ -78,7 +78,7 @@ class RxMongoDriver(system: ActorSystem, config: Config, driverProvider: RxMongo
     }
 
   private[this] def waitForAuthentication(conn: MongoConnection, auth: Authenticate): MongoConnection = {
-    wait(conn.authenticate(auth.db, auth.user, auth.password.getOrElse(""), failoverStrategy)(system.dispatcher))
+    wait(conn.authenticate(auth.db, auth.user, auth.password.getOrElse(""), failoverStrategy))
     conn
   }
   private[this] def wait[T](awaitable: Awaitable[T])(implicit duration: Duration): T =
@@ -98,7 +98,7 @@ class RxMongoDriver(system: ActorSystem, config: Config, driverProvider: RxMongo
   }
   private[mongodb] def db = connection.database(name = dbName, failoverStrategy = failoverStrategy)(system.dispatcher)
 
-  private[mongodb] override def collection(name: String)(implicit ec: ExecutionContext) = db.map(_[BSONCollection](name))(system.dispatcher)
+  private[mongodb] override def collection(name: String)(implicit ec: ExecutionContext) = db.map(_[BSONCollection](name))
 
   private[mongodb] override def ensureCollection(name: String)(implicit ec: ExecutionContext): Future[BSONCollection] =
     ensureCollection(name, _.create())

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoDatabaseConfigSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoDatabaseConfigSpec.scala
@@ -16,6 +16,8 @@ import org.scalatest.junit.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class RxMongoDatabaseConfigSpec extends BaseUnitTest with ContainerMongo with BeforeAndAfterAll with ScalaFutures {
 
+  import scala.concurrent.ExecutionContext.Implicits.global
+
   override def afterAll(): Unit = {
     cleanup()
   }

--- a/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceDriverSpec.scala
+++ b/rxmongo/src/test/scala/akka/contrib/persistence/mongodb/RxMongoPersistenceDriverSpec.scala
@@ -7,7 +7,6 @@ import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.junit.JUnitRunner
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent._
 import scala.concurrent.duration._
 
@@ -61,6 +60,8 @@ class RxMongoPersistenceDriverShutdownSpec extends BaseUnitTest with ContainerMo
 
 @RunWith(classOf[JUnitRunner])
 class RxMongoPersistenceDriverAuthSpec extends BaseUnitTest with ContainerMongo with BeforeAndAfterAll {
+
+  import ExecutionContext.Implicits.global
 
   val authMode: String = if( envMongoVersion.contains("2.6") ) "?authMode=mongocr" else "?authMode=scram-sha1"
 

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceExtension.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceExtension.scala
@@ -38,10 +38,10 @@ class ScalaMongoDriver(system: ActorSystem, config: Config) extends MongoPersist
     client.getDatabase(dbName)
   }
 
-  override private[mongodb] def collection(name: String): C =
+  override private[mongodb] def collection(name: String)(implicit ec: ExecutionContext): C =
     Future.successful(db.getCollection(name))
 
-  override private[mongodb] def ensureCollection(name: String): C = {
+  override private[mongodb] def ensureCollection(name: String)(implicit ec: ExecutionContext): C = {
     implicit val ec: ExecutionContext = system.dispatcher
 
     for {

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceExtension.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceExtension.scala
@@ -8,7 +8,7 @@ import akka.stream.ActorMaterializer
 import com.mongodb.ConnectionString
 import com.mongodb.client.model.{CreateCollectionOptions, IndexOptions}
 import com.typesafe.config.Config
-import org.mongodb.scala.bson.{BsonBoolean, BsonDocument}
+import org.mongodb.scala.bson.BsonDocument
 import org.mongodb.scala.model.Indexes._
 import org.mongodb.scala.{MongoClientSettings, _}
 
@@ -41,14 +41,15 @@ class ScalaMongoDriver(system: ActorSystem, config: Config) extends MongoPersist
   override private[mongodb] def collection(name: String)(implicit ec: ExecutionContext): C =
     Future.successful(db.getCollection(name))
 
-  override private[mongodb] def ensureCollection(name: String)(implicit ec: ExecutionContext): C = {
-    implicit val ec: ExecutionContext = system.dispatcher
+  override private[mongodb] def ensureCollection(name: String)(implicit ec: ExecutionContext): C =
+    ensureCollection(name, db.createCollection)
 
+  private[this] def ensureCollection(name: String, collectionCreator: String => SingleObservable[Completed])
+                                    (implicit ec: ExecutionContext): C =
     for {
-      _ <- db.createCollection(name).toFuture().recover { case MongoErrors.NamespaceExists() => Completed }
+      _ <- collectionCreator(name).toFuture().recover { case MongoErrors.NamespaceExists() => Completed }
       mongoCollection <- collection(name)
     } yield mongoCollection
-  }
 
   private[mongodb] def journalWriteConcern: WriteConcern = toWriteConcern(journalWriteSafety, journalWTimeout, journalFsync)
   private[mongodb] def snapsWriteConcern: WriteConcern = toWriteConcern(snapsWriteSafety, snapsWTimeout, snapsFsync)
@@ -62,29 +63,22 @@ class ScalaMongoDriver(system: ActorSystem, config: Config) extends MongoPersist
     }
 
   override private[mongodb] def cappedCollection(name: String)(implicit ec: ExecutionContext): C = {
-    def createCappedCollection(): C = {
-      val options = new CreateCollectionOptions().capped(true).sizeInBytes(realtimeCollectionSize)
-      db.createCollection(name, options)
-        .toFuture()
-        .recover({ case MongoErrors.NamespaceExists() => Completed })
-        .flatMap(_ => collection(name))
-    }
-
-    db.listCollections().filter(BsonDocument("name" -> name)).toFuture().flatMap { collections =>
-      val capped = collections.headOption
-        .flatMap(d => d.get("options"))
-        .collect{ case d: BsonDocument if d.containsKey("capped") => d.get("capped").asBoolean() }
-      if (capped.contains(BsonBoolean(true))) {
-        collection(name)
-      } else if (capped.isDefined) {
-        collection(name)
-          .flatMap(_.drop().toFuture())
-          .flatMap(_ => createCappedCollection())
-      } else {
-        createCappedCollection()
-      }
-    }
+    val cappedCollectionCreator = (ccName: String) =>
+      db.createCollection(ccName, new CreateCollectionOptions().capped(true).sizeInBytes(realtimeCollectionSize))
+    for {
+      collection <- ensureCollection(name, cappedCollectionCreator)
+      capped <- isCappedCollection(name)
+      cc <- if (capped) Future.successful(collection) else for {
+        _ <- collection.drop().toFuture()
+        recreatedCappedCollection <- ensureCollection(name, cappedCollectionCreator)
+      } yield recreatedCappedCollection
+    } yield cc
   }
+
+  private[this] def isCappedCollection(collectionName: String): Future[Boolean] =
+    db.runCommand(BsonDocument("collStats" -> collectionName))
+      .toFuture()
+      .map(stats => stats.get("capped").exists(_.asBoolean.getValue))
 
   private[mongodb] def getCollectionsAsFuture(collectionName: String)(implicit ec: ExecutionContext): Future[List[MongoCollection[D]]] = {
     getAllCollectionsAsFuture(Option(_.startsWith(collectionName)))

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceJournaller.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceJournaller.scala
@@ -30,7 +30,7 @@ class ScalaDriverPersistenceJournaller(val driver: ScalaMongoDriver) extends Mon
 
   private[this] def journal(implicit ec: ExecutionContext): driver.C = driver.journal.map(_.withWriteConcern(driver.journalWriteConcern))
 
-  private[this] def realtime: driver.C = driver.realtime
+  private[this] def realtime(implicit ec: ExecutionContext): driver.C = driver.realtime
 
   private[this] def metadata(implicit ec: ExecutionContext): driver.C = driver.metadata.map(_.withWriteConcern(driver.metadataWriteConcern))
 

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceReadJournaller.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceReadJournaller.scala
@@ -285,16 +285,16 @@ class ScalaDriverPersistenceReadJournaller(driver: ScalaMongoDriver, m: Material
   }
 
 
-  override def currentAllEvents(implicit m: Materializer): Source[Event, NotUsed] =
+  override def currentAllEvents(implicit m: Materializer, ec: ExecutionContext): Source[Event, NotUsed] =
     CurrentAllEvents.source(driver)
 
-  override def currentPersistenceIds(implicit m: Materializer): Source[String, NotUsed] =
+  override def currentPersistenceIds(implicit m: Materializer, ec: ExecutionContext): Source[String, NotUsed] =
     CurrentPersistenceIds.source(driver)
 
-  override def currentEventsByPersistenceId(persistenceId: String, fromSeq: Long, toSeq: Long)(implicit m: Materializer): Source[Event, NotUsed] =
+  override def currentEventsByPersistenceId(persistenceId: String, fromSeq: Long, toSeq: Long)(implicit m: Materializer, ec: ExecutionContext): Source[Event, NotUsed] =
     CurrentEventsByPersistenceId.source(driver, persistenceId, fromSeq, toSeq)
 
-  override def currentEventsByTag(tag: String, offset: Offset)(implicit m: Materializer): Source[(Event, Offset), NotUsed] =
+  override def currentEventsByTag(tag: String, offset: Offset)(implicit m: Materializer, ec: ExecutionContext): Source[(Event, Offset), NotUsed] =
     CurrentEventsByTag.source(driver, tag, offset)
 
   override def checkOffsetIsSupported(offset: Offset): Boolean =
@@ -303,18 +303,18 @@ class ScalaDriverPersistenceReadJournaller(driver: ScalaMongoDriver, m: Material
       case ObjectIdOffset(hexStr, _) => ObjectId.isValid(hexStr)
     }
 
-  override def liveEvents(implicit m: Materializer): Source[Event, NotUsed] =
+  override def liveEvents(implicit m: Materializer, ec: ExecutionContext): Source[Event, NotUsed] =
     journalStream.cursor(None).map{ case(e,_) => e }
 
-  override def livePersistenceIds(implicit m: Materializer): Source[String, NotUsed] =
+  override def livePersistenceIds(implicit m: Materializer, ec: ExecutionContext): Source[String, NotUsed] =
     journalStream.cursor(None).map{ case(e,_) => e.pid }
 
-  override def liveEventsByPersistenceId(persistenceId: String)(implicit m: Materializer): Source[Event, NotUsed] =
+  override def liveEventsByPersistenceId(persistenceId: String)(implicit m: Materializer, ec: ExecutionContext): Source[Event, NotUsed] =
     journalStream.cursor(
       Option(equal(PROCESSOR_ID, persistenceId))
     ).mapConcat{ case(ev,_) => List(ev).filter(_.pid == persistenceId) }
 
-  override def liveEventsByTag(tag: String, offset: Offset)(implicit m: Materializer, ord: Ordering[Offset]): Source[(Event, Offset), NotUsed] =
+  override def liveEventsByTag(tag: String, offset: Offset)(implicit m: Materializer, ec: ExecutionContext, ord: Ordering[Offset]): Source[(Event, Offset), NotUsed] =
     journalStream.cursor(
       Option(equal(TAGS, tag))
     ).filter{ case(ev, off) => ev.tags.contains(tag) &&  ord.gt(off, offset)}

--- a/scala/src/test/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceSpec.scala
+++ b/scala/src/test/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceSpec.scala
@@ -7,12 +7,11 @@ import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.junit.JUnitRunner
 
-import scala.concurrent.{Await, Future, ExecutionContext, duration}
+import scala.concurrent.{Await, Future, duration}
 import duration._
 
 @RunWith(classOf[JUnitRunner])
 class ScalaDriverPersistenceShutdownSpec extends BaseUnitTest with ContainerMongo with BeforeAndAfterAll {
-  import ExecutionContext.Implicits._
 
   override def beforeAll(): Unit = cleanup()
 

--- a/tools/src/test/scala/akka/contrib/persistence/mongodb/MigrateToSuffixedCollectionsSpec.scala
+++ b/tools/src/test/scala/akka/contrib/persistence/mongodb/MigrateToSuffixedCollectionsSpec.scala
@@ -17,6 +17,8 @@ import scala.concurrent.{ Await, Future, Promise }
 
 class MigrateToSuffixedCollectionsSpec extends BaseUnitTest with ContainerMongo with BeforeAndAfterAll {
 
+  import scala.concurrent.ExecutionContext.Implicits.global
+
   override def embedDB = s"migrate-to-suffixed-collections-test"
 
   override def afterAll() = cleanup()


### PR DESCRIPTION
## What changed?
1. Collection cache implementations are configurable.
2. All collection creation methods require implicit execution context.
3. MongoDB driver core is a dependency of the module `common`.

## Why those changes?

### 1. Configurable collection cache implementations

The previous collection caches were TrieMaps. Entries were kept for eternity. For long-running Akka clusters that experience database downtime and operations by external systems, simple TrieMap caches have 2 undesirable consequences:
1. Collections dropped by others never gets recreated with configured indexes or as capped collections. Journal read queries will take a long time due to missing indexes. Reads on realtime collections won't work at all.
2. Memory consumption grows without bound as more and more collections are created over time.

Giving users [the option to supply their own collection caches](https://github.com/scullxbones/akka-persistence-mongo/blob/c25bc97dc3a31efec01c3abcce8e3384628fc862/common/src/main/resources/reference.conf#L61-L105) addresses both problems without introducing extra dependencies into the plugin.

Sensible default implementations are included so that the plugin's behavior does not change when caches are not configured. An extra configuration `expire-after-write` is added so that users can ensure that collection attributes are eventually correct without implementing caches themselves.


### 2. Execution contexts for all collection creation methods

With suffixed journal collections enabled, collection creation happens once per persisted event in the worst case. Using global execution context or the actor system's default dispatcher for collection creation easily starves stressed systems of threads.

Instead, collection creation should use plugin dispatchers configured expressly for database operations. A [supertype of drivers ](https://github.com/scullxbones/akka-persistence-mongo/blob/c25bc97dc3a31efec01c3abcce8e3384628fc862/common/src/main/scala/akka/contrib/persistence/mongodb/WithMongoPersistencePluginDispatcher.scala) centralizes dispatcher lookup.

### 3. MongoDB driver core is a dependency of common

The extractor [MongoErrors](https://github.com/scullxbones/akka-persistence-mongo/blob/c25bc97dc3a31efec01c3abcce8e3384628fc862/common/src/main/scala/akka/contrib/persistence/mongodb/MongoErrors.scala) moved to the module `common` so that the Casbah driver can take advantage of it.

The `cappedCollection` methods of all drivers now call a private, idiosyncratic variant of `ensureCollection` (fixes #224).