### PR TITLE
Correct classloader used to load the suffix builder class

### DIFF
--- a/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistence.scala
+++ b/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistence.scala
@@ -106,7 +106,7 @@ abstract class MongoPersistenceDriver(as: ActorSystem, config: Config) {
    */
   private[this] def getSuffixFromPersistenceId(persistenceId: String): String = suffixBuilderClassOption match {
     case Some(suffixBuilderClass) if !suffixBuilderClass.trim.isEmpty =>
-      val builderClass = Class.forName(suffixBuilderClass)
+      val builderClass = Class.forName(suffixBuilderClass, true, Thread.currentThread.getContextClassLoader)
       val builderCons = builderClass.getConstructor()
       val builderIns = builderCons.newInstance().asInstanceOf[CanSuffixCollectionNames]
       builderIns.getSuffixFromPersistenceId(persistenceId)
@@ -118,7 +118,7 @@ abstract class MongoPersistenceDriver(as: ActorSystem, config: Config) {
    */
   private[this] def validateMongoCharacters(input: String): String = suffixBuilderClassOption match {
     case Some(suffixBuilderClass) if !suffixBuilderClass.trim.isEmpty =>
-      val builderClass = Class.forName(suffixBuilderClass)
+      val builderClass = Class.forName(suffixBuilderClass, true, Thread.currentThread.getContextClassLoader)
       val builderCons = builderClass.getConstructor()
       val builderIns = builderCons.newInstance().asInstanceOf[CanSuffixCollectionNames]
       builderIns.validateMongoCharacters(input)


### PR DESCRIPTION
Change from calling `Class.forName(String)` to
 `Class.forName(String, boolean, ClassLoader)` and pass in the current
 thread context classloader to allow loading of 3rd party classes in
 consumers of this library.
As per https://bugs.java.com/bugdatabase/view_bug.do?bug_id=4452032,
 `Class.forName(String)` should only be used to load JRE classes
 "(i.e., no application specific classes should ever be found)" and
 `Class.forName(String, boolean, ClassLoader)` "is more likely to work
 with both Java Web Start and Java Plug-In"
Resolve: https://github.com/scullxbones/akka-persistence-mongo/issues/227