### PR TITLE
improve the way official driver settings are used for connection

### DIFF
--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceExtension.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceExtension.scala
@@ -24,8 +24,7 @@ class ScalaMongoDriver(system: ActorSystem, config: Config) extends MongoPersist
 
   private def mongoClientSettings: MongoClientSettings =
     scalaDriverSettings
-      .configure(MongoClientSettings.builder())
-      .applyConnectionString(new ConnectionString(mongoUri))
+      .configureWithConnectionString(MongoClientSettings.builder(), new ConnectionString(mongoUri))
       .applicationName("akka-persistence-mongodb")
       .build()
 

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceExtension.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceExtension.scala
@@ -22,9 +22,9 @@ class ScalaMongoDriver(system: ActorSystem, config: Config) extends MongoPersist
   val ScalaSerializers: ScalaDriverSerializers = ScalaDriverSerializersExtension(system)
   val scalaDriverSettings: ScalaDriverSettings = ScalaDriverSettings(system)
 
-  private def mongoClientSettings: MongoClientSettings =
+  private lazy val mongoClientSettings: MongoClientSettings =
     scalaDriverSettings
-      .configureWithConnectionString(MongoClientSettings.builder(), mongoUri)
+      .configureWithUriFallback(MongoClientSettings.builder(), mongoUri)
       .applicationName("akka-persistence-mongodb")
       .build()
 

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceExtension.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceExtension.scala
@@ -24,9 +24,12 @@ class ScalaMongoDriver(system: ActorSystem, config: Config) extends MongoPersist
 
   private def mongoClientSettings: MongoClientSettings =
     scalaDriverSettings
-      .configureWithConnectionString(MongoClientSettings.builder(), new ConnectionString(mongoUri))
+      .configureWithConnectionString(MongoClientSettings.builder(), mongoUri)
       .applicationName("akka-persistence-mongodb")
       .build()
+
+  println(s">>>>>>>>>>>>>>>> URI -> $mongoUri")
+  println(s">>>>>>>>>>>>>>>> MAX WAIT QUEUE SIZE -> ${mongoClientSettings.getClusterSettings.getMaxWaitQueueSize}")
 
   private[mongodb] lazy val client = MongoClient(mongoClientSettings)
   private[mongodb] lazy val db: MongoDatabase = {

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceExtension.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceExtension.scala
@@ -22,9 +22,9 @@ class ScalaMongoDriver(system: ActorSystem, config: Config) extends MongoPersist
   val ScalaSerializers: ScalaDriverSerializers = ScalaDriverSerializersExtension(system)
   val scalaDriverSettings: ScalaDriverSettings = ScalaDriverSettings(system)
 
-  private lazy val mongoClientSettings: MongoClientSettings =
+  private[this] val mongoClientSettings: MongoClientSettings =
     scalaDriverSettings
-      .configureWithUriFallback(MongoClientSettings.builder(), mongoUri)
+      .configure(mongoUri)
       .applicationName("akka-persistence-mongodb")
       .build()
 

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceExtension.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceExtension.scala
@@ -28,9 +28,6 @@ class ScalaMongoDriver(system: ActorSystem, config: Config) extends MongoPersist
       .applicationName("akka-persistence-mongodb")
       .build()
 
-  println(s">>>>>>>>>>>>>>>> URI -> $mongoUri")
-  println(s">>>>>>>>>>>>>>>> MAX WAIT QUEUE SIZE -> ${mongoClientSettings.getClusterSettings.getMaxWaitQueueSize}")
-
   private[mongodb] lazy val client = MongoClient(mongoClientSettings)
   private[mongodb] lazy val db: MongoDatabase = {
     val dbName =

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverSettings.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverSettings.scala
@@ -34,7 +34,7 @@ object ScalaDriverSettings extends ExtensionId[ScalaDriverSettings] with Extensi
 }
 
 class ScalaDriverSettings(config: Config) extends OfficialDriverSettings(config) with Extension {
-  import ScalaDriverSettings._
+//  import ScalaDriverSettings._
 
   import scala.language.implicitConversions
 
@@ -82,7 +82,7 @@ class ScalaDriverSettings(config: Config) extends OfficialDriverSettings(config)
 //    } else bldr
 //  }
 
-  def configureWithConnectionString(b: MongoClientSettings.Builder, uri: String): MongoClientSettings.Builder = {
+  def configureWithUriFallback(b: MongoClientSettings.Builder, uri: String): MongoClientSettings.Builder = {
 
     def getLongQueryProperty(key: String): Option[Long] = getQueryProperty(key, _.toLong)
 

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverSettings.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverSettings.scala
@@ -9,6 +9,7 @@ import com.typesafe.config.Config
 import org.mongodb.scala.MongoClientSettings
 import org.mongodb.scala.connection._
 
+import scala.language.implicitConversions
 import scala.util.Try
 
 object ScalaDriverSettings extends ExtensionId[ScalaDriverSettings] with ExtensionIdProvider {
@@ -21,68 +22,11 @@ object ScalaDriverSettings extends ExtensionId[ScalaDriverSettings] with Extensi
 
   override def lookup(): ExtensionId[ScalaDriverSettings] = ScalaDriverSettings
 
-//  implicit def configbuilder2block[A](fn: A => A): Block[A] = new ConfigBuilderToBlock[A](fn)
-//
-//  private class ConfigBuilderToBlock[A](fn: A => A) extends Block[A] {
-//    def apply(a: A): Unit = {
-//      fn(a)
-//      ()
-//    }
-//  }
-//
-//  def builder[A](fn: A => A): A => A = identity[A]
 }
 
 class ScalaDriverSettings(config: Config) extends OfficialDriverSettings(config) with Extension {
-//  import ScalaDriverSettings._
 
-  import scala.language.implicitConversions
-
-//  def configure(b: MongoClientSettings.Builder): MongoClientSettings.Builder = {
-//    /*
-//        TODO: Apparently unsupported in latest driver
-//
-//        .socketKeepAlive(SocketKeepAlive)
-//        .heartbeatConnectTimeout(HeartbeatConnectTimeout.toMillis.toIntWithoutWrapping)
-//        .heartbeatSocketTimeout(HeartbeatSocketTimeout.toMillis.toIntWithoutWrapping)
-//     */
-//
-//    val bldr = b.applyToClusterSettings(
-//      builder[ClusterSettings.Builder](
-//        _.serverSelectionTimeout(ServerSelectionTimeout.toMillis, TimeUnit.MILLISECONDS)
-//         .maxWaitQueueSize(ThreadsAllowedToBlockforConnectionMultiplier)
-//      )
-//    ).applyToConnectionPoolSettings(
-//      builder[ConnectionPoolSettings.Builder](
-//        _.maxWaitTime(MaxWaitTime.toMillis, TimeUnit.MILLISECONDS)
-//          .maxConnectionIdleTime(MaxConnectionIdleTime.toMillis, TimeUnit.MILLISECONDS)
-//          .maxConnectionLifeTime(MaxConnectionLifeTime.toMillis, TimeUnit.MILLISECONDS)
-//          .minSize(MinConnectionsPerHost)
-//          .maxSize(ConnectionsPerHost)
-//      )
-//    ).applyToServerSettings(
-//      builder[ServerSettings.Builder](
-//        _.heartbeatFrequency(HeartbeatFrequency.toMillis, TimeUnit.MILLISECONDS)
-//         .minHeartbeatFrequency(MinHeartbeatFrequency.toMillis, TimeUnit.MILLISECONDS)
-//      )
-//    ).applyToSocketSettings(
-//      builder[SocketSettings.Builder](
-//        _.connectTimeout(ConnectTimeout.toMillis.toIntWithoutWrapping, TimeUnit.MILLISECONDS)
-//          .readTimeout(SocketTimeout.toMillis.toIntWithoutWrapping, TimeUnit.MILLISECONDS)
-//      )
-//    ).applyToSslSettings(
-//      builder[SslSettings.Builder](
-//        _.enabled(SslEnabled)
-//         .invalidHostNameAllowed(SslInvalidHostNameAllowed)
-//      )
-//    )
-//
-//    if (SslEnabled) {
-//      bldr.streamFactoryFactory(NettyStreamFactoryFactory())
-//    } else bldr
-//  }
-
-  def configureWithUriFallback(b: MongoClientSettings.Builder, uri: String): MongoClientSettings.Builder = {
+  def configure(uri: String): MongoClientSettings.Builder = {
 
     def getLongQueryProperty(key: String): Option[Long] = getQueryProperty(key, _.toLong)
 
@@ -100,7 +44,8 @@ class ScalaDriverSettings(config: Config) extends OfficialDriverSettings(config)
       }.getOrElse(None)
     }
 
-    val bldr: MongoClientSettings.Builder = b.applyConnectionString(new ConnectionString(uri))
+    val bldr: MongoClientSettings.Builder = MongoClientSettings.builder()
+      .applyConnectionString(new ConnectionString(uri))
       .applyToClusterSettings(new Block[ClusterSettings.Builder]{
         override def apply(t: ClusterSettings.Builder): Unit = {
           t.serverSelectionTimeout(getLongQueryProperty("serverselectiontimeoutms").getOrElse(ServerSelectionTimeout.toMillis), TimeUnit.MILLISECONDS)

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverSettings.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverSettings.scala
@@ -1,5 +1,6 @@
 package akka.contrib.persistence.mongodb
 
+import java.net.URI
 import java.util.concurrent.TimeUnit
 
 import akka.actor.{ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
@@ -7,6 +8,8 @@ import com.mongodb.{Block, ConnectionString}
 import com.typesafe.config.Config
 import org.mongodb.scala.MongoClientSettings
 import org.mongodb.scala.connection._
+
+import scala.util.Try
 
 object ScalaDriverSettings extends ExtensionId[ScalaDriverSettings] with ExtensionIdProvider {
 
@@ -18,101 +21,125 @@ object ScalaDriverSettings extends ExtensionId[ScalaDriverSettings] with Extensi
 
   override def lookup(): ExtensionId[ScalaDriverSettings] = ScalaDriverSettings
 
-  implicit def configbuilder2block[A](fn: A => A): Block[A] = new ConfigBuilderToBlock[A](fn)
-
-  private class ConfigBuilderToBlock[A](fn: A => A) extends Block[A] {
-    def apply(a: A): Unit = {
-      fn(a)
-      ()
-    }
-  }
-
-  def builder[A](fn: A => A): A => A = identity[A]
+//  implicit def configbuilder2block[A](fn: A => A): Block[A] = new ConfigBuilderToBlock[A](fn)
+//
+//  private class ConfigBuilderToBlock[A](fn: A => A) extends Block[A] {
+//    def apply(a: A): Unit = {
+//      fn(a)
+//      ()
+//    }
+//  }
+//
+//  def builder[A](fn: A => A): A => A = identity[A]
 }
 
 class ScalaDriverSettings(config: Config) extends OfficialDriverSettings(config) with Extension {
   import ScalaDriverSettings._
+
   import scala.language.implicitConversions
 
-  def configure(b: MongoClientSettings.Builder): MongoClientSettings.Builder = {
-    /*
-        TODO: Apparently unsupported in latest driver
+//  def configure(b: MongoClientSettings.Builder): MongoClientSettings.Builder = {
+//    /*
+//        TODO: Apparently unsupported in latest driver
+//
+//        .socketKeepAlive(SocketKeepAlive)
+//        .heartbeatConnectTimeout(HeartbeatConnectTimeout.toMillis.toIntWithoutWrapping)
+//        .heartbeatSocketTimeout(HeartbeatSocketTimeout.toMillis.toIntWithoutWrapping)
+//     */
+//
+//    val bldr = b.applyToClusterSettings(
+//      builder[ClusterSettings.Builder](
+//        _.serverSelectionTimeout(ServerSelectionTimeout.toMillis, TimeUnit.MILLISECONDS)
+//         .maxWaitQueueSize(ThreadsAllowedToBlockforConnectionMultiplier)
+//      )
+//    ).applyToConnectionPoolSettings(
+//      builder[ConnectionPoolSettings.Builder](
+//        _.maxWaitTime(MaxWaitTime.toMillis, TimeUnit.MILLISECONDS)
+//          .maxConnectionIdleTime(MaxConnectionIdleTime.toMillis, TimeUnit.MILLISECONDS)
+//          .maxConnectionLifeTime(MaxConnectionLifeTime.toMillis, TimeUnit.MILLISECONDS)
+//          .minSize(MinConnectionsPerHost)
+//          .maxSize(ConnectionsPerHost)
+//      )
+//    ).applyToServerSettings(
+//      builder[ServerSettings.Builder](
+//        _.heartbeatFrequency(HeartbeatFrequency.toMillis, TimeUnit.MILLISECONDS)
+//         .minHeartbeatFrequency(MinHeartbeatFrequency.toMillis, TimeUnit.MILLISECONDS)
+//      )
+//    ).applyToSocketSettings(
+//      builder[SocketSettings.Builder](
+//        _.connectTimeout(ConnectTimeout.toMillis.toIntWithoutWrapping, TimeUnit.MILLISECONDS)
+//          .readTimeout(SocketTimeout.toMillis.toIntWithoutWrapping, TimeUnit.MILLISECONDS)
+//      )
+//    ).applyToSslSettings(
+//      builder[SslSettings.Builder](
+//        _.enabled(SslEnabled)
+//         .invalidHostNameAllowed(SslInvalidHostNameAllowed)
+//      )
+//    )
+//
+//    if (SslEnabled) {
+//      bldr.streamFactoryFactory(NettyStreamFactoryFactory())
+//    } else bldr
+//  }
 
-        .socketKeepAlive(SocketKeepAlive)
-        .heartbeatConnectTimeout(HeartbeatConnectTimeout.toMillis.toIntWithoutWrapping)
-        .heartbeatSocketTimeout(HeartbeatSocketTimeout.toMillis.toIntWithoutWrapping)
-     */
+  def configureWithConnectionString(b: MongoClientSettings.Builder, uri: String): MongoClientSettings.Builder = {
 
-    val bldr = b.applyToClusterSettings(
-      builder[ClusterSettings.Builder](
-        _.serverSelectionTimeout(ServerSelectionTimeout.toMillis, TimeUnit.MILLISECONDS)
-         .maxWaitQueueSize(ThreadsAllowedToBlockforConnectionMultiplier)
-      )
-    ).applyToConnectionPoolSettings(
-      builder[ConnectionPoolSettings.Builder](
-        _.maxWaitTime(MaxWaitTime.toMillis, TimeUnit.MILLISECONDS)
-          .maxConnectionIdleTime(MaxConnectionIdleTime.toMillis, TimeUnit.MILLISECONDS)
-          .maxConnectionLifeTime(MaxConnectionLifeTime.toMillis, TimeUnit.MILLISECONDS)
-          .minSize(MinConnectionsPerHost)
-          .maxSize(ConnectionsPerHost)
-      )
-    ).applyToServerSettings(
-      builder[ServerSettings.Builder](
-        _.heartbeatFrequency(HeartbeatFrequency.toMillis, TimeUnit.MILLISECONDS)
-         .minHeartbeatFrequency(MinHeartbeatFrequency.toMillis, TimeUnit.MILLISECONDS)
-      )
-    ).applyToSocketSettings(
-      builder[SocketSettings.Builder](
-        _.connectTimeout(ConnectTimeout.toMillis.toIntWithoutWrapping, TimeUnit.MILLISECONDS)
-          .readTimeout(SocketTimeout.toMillis.toIntWithoutWrapping, TimeUnit.MILLISECONDS)
-      )
-    ).applyToSslSettings(
-      builder[SslSettings.Builder](
-        _.enabled(SslEnabled)
-         .invalidHostNameAllowed(SslInvalidHostNameAllowed)
-      )
+    def getLongQueryProperty(key: String): Option[Long] = getQueryProperty(key, _.toLong)
+
+    def getIntQueryProperty(key: String): Option[Int] = getQueryProperty(key, _.toInt)
+
+    def getBooleanQueryProperty(key: String): Option[Boolean] = getQueryProperty(key, _.toBoolean)
+
+    def getQueryProperty[T](key: String, f: String => T): Option[T] = {
+      Try {
+        new URI(uri).getQuery.split('&').collectFirst {
+          case s if s.toLowerCase.startsWith(key.toLowerCase) && s.indexOf('=') > 0 => f(s.substring(s.indexOf('=') + 1))
+        }
+      }.recover {
+        case _: Throwable => None
+      }.getOrElse(None)
+    }
+
+    val bldr: MongoClientSettings.Builder = b.applyConnectionString(new ConnectionString(uri))
+      .applyToClusterSettings(new Block[ClusterSettings.Builder]{
+        override def apply(t: ClusterSettings.Builder): Unit = {
+          t.serverSelectionTimeout(getLongQueryProperty("serverselectiontimeoutms").getOrElse(ServerSelectionTimeout.toMillis), TimeUnit.MILLISECONDS)
+            .maxWaitQueueSize(getIntQueryProperty("waitqueuemultiple").getOrElse(ThreadsAllowedToBlockforConnectionMultiplier) * getIntQueryProperty("maxpoolsize").getOrElse(ConnectionsPerHost))
+        }
+      }
+    ).applyToConnectionPoolSettings(new Block[ConnectionPoolSettings.Builder]{
+        override def apply(t: ConnectionPoolSettings.Builder): Unit = {
+          t.maxWaitTime(getLongQueryProperty("waitqueuetimeoutms").getOrElse(MaxWaitTime.toMillis), TimeUnit.MILLISECONDS)
+            .maxConnectionIdleTime(getLongQueryProperty("maxidletimems").getOrElse(MaxConnectionIdleTime.toMillis), TimeUnit.MILLISECONDS)
+            .maxConnectionLifeTime(getLongQueryProperty("maxlifetimems").getOrElse(MaxConnectionLifeTime.toMillis), TimeUnit.MILLISECONDS)
+            .minSize(getIntQueryProperty("minpoolsize").getOrElse(MinConnectionsPerHost))
+            .maxSize(getIntQueryProperty("maxpoolsize").getOrElse(ConnectionsPerHost))
+        }
+      }
+    ).applyToServerSettings(new Block[ServerSettings.Builder]{
+        override def apply(t: ServerSettings.Builder): Unit = {
+          t.heartbeatFrequency(getLongQueryProperty("heartbeatfrequencyms").getOrElse(HeartbeatFrequency.toMillis), TimeUnit.MILLISECONDS)
+            .minHeartbeatFrequency(MinHeartbeatFrequency.toMillis, TimeUnit.MILLISECONDS) // no 'minHeartbeatFrequency' in ConnectionString ???
+        }
+      }
+    ).applyToSocketSettings(new Block[SocketSettings.Builder] {
+      override def apply(t: SocketSettings.Builder): Unit = {
+          t.connectTimeout(getLongQueryProperty("connecttimeoutms").getOrElse(ConnectTimeout.toMillis).toIntWithoutWrapping, TimeUnit.MILLISECONDS)
+            .readTimeout(getLongQueryProperty("sockettimeoutms").getOrElse(SocketTimeout.toMillis).toIntWithoutWrapping, TimeUnit.MILLISECONDS)
+        }
+      }
+    ).applyToSslSettings(new Block[SslSettings.Builder]{
+      override def apply(t: SslSettings.Builder): Unit = {
+          t.enabled(getBooleanQueryProperty("ssl").getOrElse(SslEnabled))
+            .invalidHostNameAllowed(getBooleanQueryProperty("sslinvalidhostnameallowed").getOrElse(SslInvalidHostNameAllowed))
+        }
+      }
     )
 
     if (SslEnabled) {
       bldr.streamFactoryFactory(NettyStreamFactoryFactory())
     } else bldr
-  }
 
-  def configureWithConnectionString(b: MongoClientSettings.Builder, c: ConnectionString): MongoClientSettings.Builder = {
+  }  
 
-    val bldr = b.applyConnectionString(c)
-    .applyToClusterSettings(
-      builder[ClusterSettings.Builder](
-        _.serverSelectionTimeout(Option(c.getServerSelectionTimeout.toLong).getOrElse(ServerSelectionTimeout.toMillis), TimeUnit.MILLISECONDS)
-          .maxWaitQueueSize(Option(c.getThreadsAllowedToBlockForConnectionMultiplier.toInt).getOrElse(ThreadsAllowedToBlockforConnectionMultiplier))
-      )
-    ).applyToConnectionPoolSettings(
-      builder[ConnectionPoolSettings.Builder](
-        _.maxWaitTime(Option(c.getMaxWaitTime.toLong).getOrElse(MaxWaitTime.toMillis), TimeUnit.MILLISECONDS)
-          .maxConnectionIdleTime(Option(c.getMaxConnectionIdleTime.toLong).getOrElse(MaxConnectionIdleTime.toMillis), TimeUnit.MILLISECONDS)
-          .maxConnectionLifeTime(Option(c.getMaxConnectionLifeTime.toLong).getOrElse(MaxConnectionLifeTime.toMillis), TimeUnit.MILLISECONDS)
-          .minSize(Option(c.getMinConnectionPoolSize.toInt).getOrElse(MinConnectionsPerHost))
-          .maxSize(Option(c.getMaxConnectionPoolSize.toInt).getOrElse(ConnectionsPerHost))
-      )
-    ).applyToServerSettings(
-      builder[ServerSettings.Builder](
-        _.heartbeatFrequency(Option(c.getHeartbeatFrequency.toLong).getOrElse(HeartbeatFrequency.toMillis), TimeUnit.MILLISECONDS)
-          .minHeartbeatFrequency(MinHeartbeatFrequency.toMillis, TimeUnit.MILLISECONDS) // no 'minHeartbeatFrequency' in ConnectionString
-      )
-    ).applyToSocketSettings(
-      builder[SocketSettings.Builder](
-        _.connectTimeout(Option(c.getConnectTimeout.toLong).getOrElse(ConnectTimeout.toMillis).toIntWithoutWrapping, TimeUnit.MILLISECONDS)
-          .readTimeout(Option(c.getSocketTimeout.toLong).getOrElse(SocketTimeout.toMillis).toIntWithoutWrapping, TimeUnit.MILLISECONDS)
-      )
-    ).applyToSslSettings(
-      builder[SslSettings.Builder](
-        _.enabled(Option[Boolean](c.getSslEnabled).getOrElse(SslEnabled))
-          .invalidHostNameAllowed(Option[Boolean](c.getSslInvalidHostnameAllowed).getOrElse(SslInvalidHostNameAllowed))
-      )
-    )
-
-    if (SslEnabled) {
-      bldr.streamFactoryFactory(NettyStreamFactoryFactory())
-    } else bldr
-  }
 }

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverSettings.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverSettings.scala
@@ -119,7 +119,7 @@ class ScalaDriverSettings(config: Config) extends OfficialDriverSettings(config)
     ).applyToServerSettings(new Block[ServerSettings.Builder]{
         override def apply(t: ServerSettings.Builder): Unit = {
           t.heartbeatFrequency(getLongQueryProperty("heartbeatfrequencyms").getOrElse(HeartbeatFrequency.toMillis), TimeUnit.MILLISECONDS)
-            .minHeartbeatFrequency(MinHeartbeatFrequency.toMillis, TimeUnit.MILLISECONDS) // no 'minHeartbeatFrequency' in ConnectionString ???
+            .minHeartbeatFrequency(MinHeartbeatFrequency.toMillis, TimeUnit.MILLISECONDS) // no 'minHeartbeatFrequency' in ConnectionString
         }
       }
     ).applyToSocketSettings(new Block[SocketSettings.Builder] {

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverSettings.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverSettings.scala
@@ -3,7 +3,7 @@ package akka.contrib.persistence.mongodb
 import java.util.concurrent.TimeUnit
 
 import akka.actor.{ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
-import com.mongodb.Block
+import com.mongodb.{Block, ConnectionString}
 import com.typesafe.config.Config
 import org.mongodb.scala.MongoClientSettings
 import org.mongodb.scala.connection._
@@ -70,6 +70,44 @@ class ScalaDriverSettings(config: Config) extends OfficialDriverSettings(config)
       builder[SslSettings.Builder](
         _.enabled(SslEnabled)
          .invalidHostNameAllowed(SslInvalidHostNameAllowed)
+      )
+    )
+
+    if (SslEnabled) {
+      bldr.streamFactoryFactory(NettyStreamFactoryFactory())
+    } else bldr
+  }
+
+  def configureWithConnectionString(b: MongoClientSettings.Builder, c: ConnectionString): MongoClientSettings.Builder = {
+
+    val bldr = b.applyConnectionString(c)
+    .applyToClusterSettings(
+      builder[ClusterSettings.Builder](
+        _.serverSelectionTimeout(Option(c.getServerSelectionTimeout.toLong).getOrElse(ServerSelectionTimeout.toMillis), TimeUnit.MILLISECONDS)
+          .maxWaitQueueSize(Option(c.getThreadsAllowedToBlockForConnectionMultiplier.toInt).getOrElse(ThreadsAllowedToBlockforConnectionMultiplier))
+      )
+    ).applyToConnectionPoolSettings(
+      builder[ConnectionPoolSettings.Builder](
+        _.maxWaitTime(Option(c.getMaxWaitTime.toLong).getOrElse(MaxWaitTime.toMillis), TimeUnit.MILLISECONDS)
+          .maxConnectionIdleTime(Option(c.getMaxConnectionIdleTime.toLong).getOrElse(MaxConnectionIdleTime.toMillis), TimeUnit.MILLISECONDS)
+          .maxConnectionLifeTime(Option(c.getMaxConnectionLifeTime.toLong).getOrElse(MaxConnectionLifeTime.toMillis), TimeUnit.MILLISECONDS)
+          .minSize(Option(c.getMinConnectionPoolSize.toInt).getOrElse(MinConnectionsPerHost))
+          .maxSize(Option(c.getMaxConnectionPoolSize.toInt).getOrElse(ConnectionsPerHost))
+      )
+    ).applyToServerSettings(
+      builder[ServerSettings.Builder](
+        _.heartbeatFrequency(Option(c.getHeartbeatFrequency.toLong).getOrElse(HeartbeatFrequency.toMillis), TimeUnit.MILLISECONDS)
+          .minHeartbeatFrequency(MinHeartbeatFrequency.toMillis, TimeUnit.MILLISECONDS) // no 'minHeartbeatFrequency' in ConnectionString
+      )
+    ).applyToSocketSettings(
+      builder[SocketSettings.Builder](
+        _.connectTimeout(Option(c.getConnectTimeout.toLong).getOrElse(ConnectTimeout.toMillis).toIntWithoutWrapping, TimeUnit.MILLISECONDS)
+          .readTimeout(Option(c.getSocketTimeout.toLong).getOrElse(SocketTimeout.toMillis).toIntWithoutWrapping, TimeUnit.MILLISECONDS)
+      )
+    ).applyToSslSettings(
+      builder[SslSettings.Builder](
+        _.enabled(Option[Boolean](c.getSslEnabled).getOrElse(SslEnabled))
+          .invalidHostNameAllowed(Option[Boolean](c.getSslInvalidHostnameAllowed).getOrElse(SslInvalidHostNameAllowed))
       )
     )
 


### PR DESCRIPTION
Hi,

This PR is about the way official Scala driver settings are handled during connection process.

Some settings, set through "akka.contrib.persistence.mongodb.mongo.official" config path, are simply ignored, because they are actually overridden when `applyConnectionString` method is called.

For example, setting `maxpoolsize` property has no effect as it is overridden with some default value  during the call to `ClusterSettings.Builder` `applyConnectionString` method:

```
public Builder applyConnectionString(final ConnectionString connectionString) {
   // ...
            Integer maxConnectionPoolSize = connectionString.getMaxConnectionPoolSize();
            int maxSize = maxConnectionPoolSize != null ? maxConnectionPoolSize : 100;
  // ...
        }
```

So, for now, the only way to actually set this property is to provide a "mongouri" property like this one:
`mongouri =  "mongodb://127.0.0.1:27017/akka-persistence?maxPoolSize=500"`

I guess this "mongouri" property may become a little bit tedious to write if we need to provide several properties...

This is why I have changed the way settings are handled:
* we first call `applyConnectionString` method in order to build a minimal `MongoClientSettings.Builder`
* we then configure this builder with values from "akka.contrib.persistence.mongodb.mongo.official" config path, **except** if they are already present inside the "mongouri" property.

This way, a setting present in "mongouri" actually overrides its counterpart in "akka.contrib.persistence.mongodb.mongo.official", but does not ignore it if not present in "mongouri".

I did not remove the `configure(b: MongoClientSettings.Builder): MongoClientSettings.Builder` method in `ScalaDriverSettings` class, but I guess it is no more useful now.

Happy reviewing...