### PR TITLE
Do not manually generate Mongo ObjectIds on the client. Let MongoDB to create them.

### DIFF
--- a/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahSerializers.scala
+++ b/casbah/src/main/scala/akka/contrib/persistence/mongodb/CasbahSerializers.scala
@@ -78,7 +78,7 @@ class CasbahSerializers(dynamicAccess: DynamicAccess, actorSystem: ActorSystem) 
   }
 
   implicit object Serializer extends CanSerializeJournal[DBObject] {
-    override def serializeAtom(atom: Atom): DBObject = {
+    override def serializeAtom(atom: Atom, realtimeEnablePersistence: Boolean): DBObject = {
       Option(atom.tags).filter(_.nonEmpty).foldLeft(
         MongoDBObject(
           ID -> ObjectId.get(),

--- a/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournallerSpec.scala
+++ b/casbah/src/test/scala/akka/contrib/persistence/mongodb/CasbahPersistenceJournallerSpec.scala
@@ -84,7 +84,7 @@ class CasbahPersistenceJournallerSpec extends TestKit(ActorSystem("unit-test")) 
       def serialize(ref:ActorRef,casbahSerializers: CasbahSerializers): DBObject ={
         val myPayload = Payload[com.mongodb.DBObject](ShardRegionTerminated(ref))(casbahSerializers.serialization,implicitly,casbahSerializers.dt,casbahSerializers.loader)
         val repr = Atom(pid = "pid", from = 1L, to = 1L, events = ISeq(Event(pid = "pid", sn = 1L, payload = myPayload)))
-        val serialized = serializeAtom(repr)
+        val serialized = serializeAtom(repr, realtimeEnablePersistence = true)
         serialized
       }
 
@@ -121,7 +121,7 @@ class CasbahPersistenceJournallerSpec extends TestKit(ActorSystem("unit-test")) 
 
       val repr = Atom(pid = "pid", from = 1L, to = 1L, events = ISeq(Event(pid = "pid", sn = 1L, payload = "TEST")))
 
-      val serialized = serializeAtom(repr)
+      val serialized = serializeAtom(repr, realtimeEnablePersistence = true)
 
       val atom = serialized
 

--- a/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistence.scala
+++ b/common/src/main/scala/akka/contrib/persistence/mongodb/MongoPersistence.scala
@@ -42,7 +42,7 @@ object MongoPersistenceDriver {
 }
 
 trait CanSerializeJournal[D] {
-  def serializeAtom(atom: Atom): D
+  def serializeAtom(atom: Atom, realtimeEnablePersistence: Boolean): D
 }
 
 trait CanDeserializeJournal[D] {
@@ -289,5 +289,5 @@ abstract class MongoPersistenceDriver(as: ActorSystem, config: Config)
 
   def deserializeJournal(dbo: D)(implicit ev: CanDeserializeJournal[D]): Event = ev.deserializeDocument(dbo)
 
-  def serializeJournal(aw: Atom)(implicit ev: CanSerializeJournal[D]): D = ev.serializeAtom(aw)
+  def serializeJournal(aw: Atom)(implicit ev: CanSerializeJournal[D]): D = ev.serializeAtom(aw, realtimeEnablePersistence)
 }

--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoSerializers.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoSerializers.scala
@@ -164,7 +164,6 @@ class RxMongoSerializers(dynamicAccess: DynamicAccess, actorSystem: ActorSystem)
     override def serializeAtom(atom: Atom): BSONDocument = {
       Option(atom.tags).filter(_.nonEmpty).foldLeft(
         BSONDocument(
-          ID -> BSONObjectID.generate(),
           PROCESSOR_ID -> atom.pid,
           FROM -> atom.from,
           TO -> atom.to,

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverSerializers.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverSerializers.scala
@@ -103,7 +103,7 @@ class ScalaDriverSerializers(dynamicAccess: DynamicAccess, actorSystem: ActorSys
   }
 
   implicit object Serializer extends CanSerializeJournal[BsonDocument] with DefaultBsonTransformers {
-    override def serializeAtom(atom: Atom): BsonDocument = {
+    override def serializeAtom(atom: Atom, realtimeEnablePersistence: Boolean): BsonDocument = {
       Option(atom.tags).filter(_.nonEmpty).foldLeft(
         BsonDocument(
           ID -> BsonObjectId(),


### PR DESCRIPTION
I was persisting 1000 events in a multi concurrent scenario, and then I was pulling them using "currentEventsByTag" passing in the correct offset each time but the total of events pulled was random between the range 850-999, but never 1000.
This is because the following:
Suppose that ObjectIds were natural integers. What I saw in Mongo was that documents were stored like this:
*1
*2
*4
*3
*5
*6
These numbers above are ObjectIds. 
The issue occurs when I pull the events using "currentEventsByTag" and the last event I got from the Source is *4. 
When I got *4 I keep the Offset, so the next time I call "currentEventsByTag" passing in that Offset, the query brings *5, *6 but it never brings *3, so that event is lost.
So because ObjectId is being generated manually, in a concurrent scenario there is a gap between the creation and the actual persist, so order of ObjectIds is not guaranteed in MongoDB. 


