### PR TITLE
Improve collections count

### DIFF
--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoJournaller.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoJournaller.scala
@@ -205,7 +205,7 @@ class RxMongoJournaller(val driver: RxMongoDriver) extends MongoPersistenceJourn
     } yield {
       if (driver.useSuffixedCollectionNames && driver.suffixDropEmpty && removed.ok)
         for {
-          n <- journal.count()
+          n <- journal.count(limit = 1)
           if n == 0
           _ <- journal.drop(failIfNotFound = false)
           _ = driver.removeJournalInCache(persistenceId)

--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoSnapshotter.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoSnapshotter.scala
@@ -48,7 +48,7 @@ class RxMongoSnapshotter(driver: RxMongoDriver) extends MongoPersistenceSnapshot
     } yield {
       if (driver.useSuffixedCollectionNames && driver.suffixDropEmpty && wr.ok)
         for {
-          n <- s.count()
+          n <- s.count(limit = 1)
             if n == 0
           _ <- s.drop(failIfNotFound = false)
           _ = driver.removeSnapsInCache(pid)
@@ -67,7 +67,7 @@ class RxMongoSnapshotter(driver: RxMongoDriver) extends MongoPersistenceSnapshot
     } yield {
       if (driver.useSuffixedCollectionNames && driver.suffixDropEmpty && wr.ok)
         for {
-          n <- s.count()
+          n <- s.count(limit = 1)
             if n == 0
           _ <- s.drop(failIfNotFound = false)
           _ = driver.removeSnapsInCache(pid)

--- a/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoSnapshotter.scala
+++ b/rxmongo/src/main/scala/akka/contrib/persistence/mongodb/RxMongoSnapshotter.scala
@@ -7,7 +7,6 @@
 package akka.contrib.persistence.mongodb
 
 import akka.persistence.SelectedSnapshot
-import reactivemongo.api.ReadConcern
 import reactivemongo.api.indexes._
 import reactivemongo.bson._
 
@@ -56,12 +55,8 @@ class RxMongoSnapshotter(driver: RxMongoDriver) extends MongoPersistenceSnapshot
       wr <- s.delete().one(BSONDocument(criteria: _*))
     } yield {
       if (driver.useSuffixedCollectionNames && driver.suffixDropEmpty && wr.ok)
-        for {
-          n <- s.count(None, None, 0, None, ReadConcern.Local)
-            if n == 0
-          _ <- s.drop(failIfNotFound = false)
-          _ = driver.removeSnapsInCache(pid)
-        } yield ()
+        driver.removeEmptySnapshot(s)
+          .map(_ => driver.removeSnapsInCache(pid))
       ()
     }
   }
@@ -77,12 +72,8 @@ class RxMongoSnapshotter(driver: RxMongoDriver) extends MongoPersistenceSnapshot
               ))
     } yield {
       if (driver.useSuffixedCollectionNames && driver.suffixDropEmpty && wr.ok)
-        for {
-          n <- s.count(None, None, 0, None, ReadConcern.Local)
-            if n == 0
-          _ <- s.drop(failIfNotFound = false)
-          _ = driver.removeSnapsInCache(pid)
-        } yield ()
+        driver.removeEmptySnapshot(s)
+          .map(_ => driver.removeSnapsInCache(pid))
       ()
     }
   }

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceExtension.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceExtension.scala
@@ -110,11 +110,11 @@ class ScalaMongoDriver(system: ActorSystem, config: Config) extends MongoPersist
     removeEmptyCollection(snp, snapsIndexName)
 
   private[this] var mongoVersion: Option[String] = None
-  private[this] def getMongoVersion: Future[String] = mongoVersion match {
+  private[this] def getMongoVersion(implicit ec: ExecutionContext): Future[String] = mongoVersion match {
     case Some(v) => Future.successful(v)
     case None =>
       db.runCommand(BsonDocument("buildInfo" -> 1)).toFuture()
-        .map(_.get("version").getOrElse(BsonString("")).asString().getValue)
+        .map(_.getOrElse[BsonString]("version", BsonString("")).getValue)
         .map { v =>
           mongoVersion = Some(v)
           v

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceExtension.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceExtension.scala
@@ -9,6 +9,7 @@ import com.mongodb.ConnectionString
 import com.mongodb.client.model.{CreateCollectionOptions, IndexOptions}
 import com.typesafe.config.Config
 import org.mongodb.scala.bson.BsonDocument
+import org.mongodb.scala.model.CountOptions
 import org.mongodb.scala.model.Indexes._
 import org.mongodb.scala.{MongoClientSettings, _}
 
@@ -101,6 +102,78 @@ class ScalaMongoDriver(system: ActorSystem, config: Config) extends MongoPersist
   private[mongodb] def journalCollectionsAsFuture(implicit ec: ExecutionContext) = getCollectionsAsFuture(journalCollectionName)
 
   private[mongodb] def snapshotCollectionsAsFuture(implicit ec: ExecutionContext) = getCollectionsAsFuture(snapsCollectionName)
+
+  private[mongodb] def removeEmptyJournal(jnl: MongoCollection[D])(implicit ec: ExecutionContext): Future[Unit] =
+    removeEmptyCollection(jnl, journalIndexName)
+
+  private[mongodb] def removeEmptySnapshot(snp: MongoCollection[D])(implicit ec: ExecutionContext): Future[Unit] =
+    removeEmptyCollection(snp, snapsIndexName)
+
+  private[this] var mongoVersion: Option[String] = None
+  private[this] def getMongoVersion: Future[String] = mongoVersion match {
+    case Some(v) => Future.successful(v)
+    case None =>
+      db.runCommand(BsonDocument("buildInfo" -> 1)).toFuture()
+        .map(_.get("version").getOrElse("").asInstanceOf[String])
+        .map { v =>
+          mongoVersion = Some(v)
+          v
+        }
+  }
+
+  private[this] def isMongoVersionAtLeast(inputNbs: Int*)(implicit ec: ExecutionContext): Future[Boolean] =
+    getMongoVersion.map {
+        case str if str.isEmpty => false
+        case str =>
+          val versionNbs = str.split('.').map(_.toInt)
+          inputNbs.zip(versionNbs).forall { case (i,v) => v >= i }
+      }
+
+  private[this] def getLocalCount(collection: MongoCollection[D])(implicit ec: ExecutionContext): Future[Long] = {
+    db.runCommand(BsonDocument("count" -> s"${collection.namespace}", "readConcern" -> "local"))
+      .toFuture()
+      .map(_.getOrElse("n", 0L).asInt32().longValue())
+  }
+
+  private[this] def getIndexAsBson(collection: MongoCollection[D], indexName: String)(implicit ec: ExecutionContext): Future[Option[BsonDocument]] =
+    for {
+      indexList <- collection.listIndexes[BsonDocument]().toFuture()
+      indexDoc = indexList.find(_.get("name").asString().getValue.equals(indexName))
+      indexKey = indexDoc match {
+          case Some(doc) => Some(doc.get("key").asDocument())
+          case None => None
+        }
+    } yield indexKey
+
+  private[this] def removeEmptyCollection(collection: MongoCollection[D], indexName: String)(implicit ec: ExecutionContext): Future[Unit] =
+    for {
+      b403 <- isMongoVersionAtLeast(4,0,3)
+      // first count, may be inaccurate in cluster environment
+      firstCount <- if (b403) {
+          collection.estimatedDocumentCount().toFuture()
+        } else {
+          getLocalCount(collection)
+        }
+      // just to be sure...
+      if firstCount == 0L
+        // second count, always accurate and should be fast as we are pretty sure the result is zero
+        secondCount <-
+          for {
+            b36 <- isMongoVersionAtLeast(3,6)
+            if b36 // lets optimize aggregate method, using appropriate index (that we have to grab from indexes list)
+              indexKey <- getIndexAsBson(collection, indexName)
+            count <- if (b36) {
+                indexKey match {
+                  case Some(index) => collection.countDocuments(BsonDocument(), CountOptions().hint(index)).toFuture()
+                  case None => collection.countDocuments().toFuture()
+                }
+              } else {
+                collection.countDocuments().toFuture()
+              }
+          } yield count
+      if secondCount == 0L
+        _ <- collection.drop().toFuture().recover { case _ => Completed() } // ignore errors
+    } yield ()
 
   override private[mongodb] def ensureIndex(indexName: String, unique: Boolean, sparse: Boolean, fields: (String, Int)*)(implicit ec: ExecutionContext): C => C = { collection =>
     for {

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceExtension.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceExtension.scala
@@ -114,7 +114,7 @@ class ScalaMongoDriver(system: ActorSystem, config: Config) extends MongoPersist
     case Some(v) => Future.successful(v)
     case None =>
       db.runCommand(BsonDocument("buildInfo" -> 1)).toFuture()
-        .map(_.getOrElse[BsonString]("version", BsonString("")).getValue)
+        .map(_.get("version").getOrElse(BsonString("")).asString().getValue)
         .map { v =>
           mongoVersion = Some(v)
           v

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceJournaller.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceJournaller.scala
@@ -199,7 +199,7 @@ class ScalaDriverPersistenceJournaller(val driver: ScalaMongoDriver) extends Mon
     } yield {
       if (driver.useSuffixedCollectionNames && driver.suffixDropEmpty && removed.wasAcknowledged())
         for {
-          n <- journal.countDocuments().toFuture()
+          n <- journal.estimatedDocumentCount().toFuture()
           if n == 0
           _ <- journal.drop().toFuture().recover{ case _ => Completed() } // ignore errors
           _ = driver.removeJournalInCache(persistenceId)

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceJournaller.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceJournaller.scala
@@ -199,12 +199,8 @@ class ScalaDriverPersistenceJournaller(val driver: ScalaMongoDriver) extends Mon
 
     } yield {
       if (driver.useSuffixedCollectionNames && driver.suffixDropEmpty && removed.wasAcknowledged())
-        for {
-          n <- journal.estimatedDocumentCount().toFuture()
-          if n == 0
-          _ <- journal.drop().toFuture().recover{ case _ => Completed() } // ignore errors
-          _ = driver.removeJournalInCache(persistenceId)
-        } yield ()
+        driver.removeEmptyJournal(journal)
+          .map(_ => driver.removeJournalInCache(persistenceId))
       ()
     }
   }

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceSnapshotter.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceSnapshotter.scala
@@ -111,10 +111,7 @@ class ScalaDriverPersistenceSnapshotter(driver: ScalaMongoDriver) extends MongoP
       wr <- s.deleteMany(criteria).toFuture()
     } yield {
       if (driver.useSuffixedCollectionNames && driver.suffixDropEmpty && wr.wasAcknowledged())
-        for {
-          n <- s.estimatedDocumentCount().toFuture() if n == 0
-          _ <- s.drop().toFuture()
-        } yield ()
+        driver.removeEmptySnapshot(s)
       ()
     }
   }
@@ -131,10 +128,7 @@ class ScalaDriverPersistenceSnapshotter(driver: ScalaMongoDriver) extends MongoP
             ).toFuture()
     } yield {
       if (driver.useSuffixedCollectionNames && driver.suffixDropEmpty && wr.wasAcknowledged())
-        for {
-          n <- s.estimatedDocumentCount().toFuture() if n == 0L
-          _ <- s.drop().toFuture()
-        } yield ()
+        driver.removeEmptySnapshot(s)
       ()
     }
   }

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceSnapshotter.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceSnapshotter.scala
@@ -112,7 +112,7 @@ class ScalaDriverPersistenceSnapshotter(driver: ScalaMongoDriver) extends MongoP
     } yield {
       if (driver.useSuffixedCollectionNames && driver.suffixDropEmpty && wr.wasAcknowledged())
         for {
-          n <- s.countDocuments().toFuture() if n == 0
+          n <- s.estimatedDocumentCount().toFuture() if n == 0
           _ <- s.drop().toFuture()
         } yield ()
       ()
@@ -132,7 +132,7 @@ class ScalaDriverPersistenceSnapshotter(driver: ScalaMongoDriver) extends MongoP
     } yield {
       if (driver.useSuffixedCollectionNames && driver.suffixDropEmpty && wr.wasAcknowledged())
         for {
-          n <- s.countDocuments().toFuture() if n == 0L
+          n <- s.estimatedDocumentCount().toFuture() if n == 0L
           _ <- s.drop().toFuture()
         } yield ()
       ()


### PR DESCRIPTION
Hi,

This PR is about the ability to drop suffixed collections if empty.

For now, we used the `countDocuments` method that performs an _aggregate_ operation in order to count all documents of the collection, which may be resource consuming if the collection contains a huge amount of data.

However, as we only need to know if the collection is actually empty and **not** how many documents it contains, a better way could be to use the 'estimatedDocumentCount' method that sends us an immediate answer from metadata, performing no counting at all (as I understand from MongoDB documentation)

Happy reviewing
