### PR TITLE
workaround for DocumentDB to retrieve maxSequenceNr without sorting on the compound index

### DIFF
--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceJournaller.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceJournaller.scala
@@ -215,7 +215,11 @@ class ScalaDriverPersistenceJournaller(val driver: ScalaMongoDriver) extends Mon
     val journal = driver.getJournal(pid)
     journal.flatMap(_.find(BsonDocument(PROCESSOR_ID -> pid))
       .projection(BsonDocument(TO -> 1))
-      .sort(BsonDocument(TO -> -1))
+      .sort(BsonDocument(
+        TO -> -1,
+        // this is a workaround for DocumentDB as it would otherwise sort on the compound index due to different optimizations. has no negative effect on MongoDB
+        PROCESSOR_ID -> 1
+      ))
       .first()
       .toFutureOption()
       .map(d => d.flatMap(a => Option(a.asDocument().get(TO)).filter(_.isInt64).map(_.asInt64).map(_.getValue)))

--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceJournaller.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceJournaller.scala
@@ -216,9 +216,9 @@ class ScalaDriverPersistenceJournaller(val driver: ScalaMongoDriver) extends Mon
     journal.flatMap(_.find(BsonDocument(PROCESSOR_ID -> pid))
       .projection(BsonDocument(TO -> 1))
       .sort(BsonDocument(
-        TO -> -1,
-        // this is a workaround for DocumentDB as it would otherwise sort on the compound index due to different optimizations. has no negative effect on MongoDB
-        PROCESSOR_ID -> 1
+        // the PROCESSOR_ID is a workaround for DocumentDB as it would otherwise sort on the compound index due to different optimizations. has no negative effect on MongoDB
+        PROCESSOR_ID -> 1,
+        TO -> -1
       ))
       .first()
       .toFutureOption()


### PR DESCRIPTION
I guess nothing additionally to test here?

fixes https://github.com/scullxbones/akka-persistence-mongo/issues/328