### PR TITLE
Removed "applicationName" setting on mongo client (scala driver only)

### DIFF
--- a/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceExtension.scala
+++ b/scala/src/main/scala/akka/contrib/persistence/mongodb/ScalaDriverPersistenceExtension.scala
@@ -25,7 +25,6 @@ class ScalaMongoDriver(system: ActorSystem, config: Config) extends MongoPersist
   val mongoClientSettings: MongoClientSettings =
     scalaDriverSettings
       .configure(mongoUri)
-      .applicationName("akka-persistence-mongodb")
       .build()
 
   lazy val client: MongoClient = MongoClient(mongoClientSettings)


### PR DESCRIPTION
Rely instead on "appName" option URI : https://docs.mongodb.com/manual/reference/connection-string/#urioption.appName

Fix for https://github.com/scullxbones/akka-persistence-mongo/issues/407