### PR TITLE
support rollback from pekko migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 * Test suite verifies against MongoDB 3.6, 4.0, 4.2
 
+### Preparing to migrate to Apache Pekko? Use 4.x Series.
+
+* Provides forwards compatibility for Akka / Pekko features that persist internal class names, allowing for you to safely roll back your application after migration.
+
 ### Using Akka 2.6? Use 3.x Series.
 [![Build Status](https://travis-ci.com/scullxbones/akka-persistence-mongo.svg?branch=master)](https://travis-ci.org/scullxbones/akka-persistence-mongo)
 ![Maven Central 2.12](https://maven-badges.herokuapp.com/maven-central/com.github.scullxbones/akka-persistence-mongo-common_2.12/badge.svg)

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val releaseV = "3.0.8"
+val releaseV = "4.0.0"
 
 val scala212V = "2.12.15"
 val scala213V = "2.13.7"


### PR DESCRIPTION
See https://github.com/scullxbones/pekko-persistence-mongo/pull/14 for the equivalent compatibility change in the pekko version of the plugin and this issue https://github.com/scullxbones/pekko-persistence-mongo/issues/10 for why this is necessary. Since not supporting this would result in a corrupted data store if trying to roll back, providing this capability is necessary for people to be willing to migrate safely.